### PR TITLE
docs(notifications): enhance endpoint notification count details

### DIFF
--- a/developer/Technical Documentation/Others/Notifications.md
+++ b/developer/Technical Documentation/Others/Notifications.md
@@ -92,7 +92,7 @@ Via the user token, all relevant information will get fetched from the portal db
 <br>
 
 ```diff
-! GET /api/notification/count-details
+! GET /api/notification/count
 ```
 
 <br>
@@ -109,11 +109,25 @@ The endpoint is a pure calculation/counting of the different metadata found belo
 * infoUnread
 * offerUnread
 * actionRequired
+* unreadActionRequired
 <br>
 
 ```diff
 ! GET /api/notification/count-details
 ```
+
+<br>
+
+Response Body
+
+          {
+            "read": 18,
+            "unread": 30,
+            "infoUnread": 11,
+            "offerUnread": 1,
+            "actionRequired": 25,
+            "unreadActionRequired": 18
+          }
 
 <br>
 <br>


### PR DESCRIPTION
## Description

Enhanced notification documentation.
Endpoint Get: /api/notification/count-details got updated.
 
What got changed:
- add an additional key - actionRequiredUnread

Key/Attribute logic:
* actionRequired: only counts those "actionRequired" notifications, which are not done
* actionRequiredUnread: counts all unread "actionRequired" notifications


## Why

Enhancing the portal documentation of the notification service since the endpoint for /count-details got enhanced with additional attributes as well as an update of the business logic

## Issue

n/a

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
