### PR TITLE
bugfix(documentation): load data from eclipse repo

### DIFF
--- a/public/documentation/js/Settings.js
+++ b/public/documentation/js/Settings.js
@@ -18,8 +18,8 @@
  ********************************************************************************/
 
 export const Settings = {
-    DOCBASE: 'https://raw.githubusercontent.com/catenax-ng/tx-portal-assets',
-    SRCBASE: 'https://github.com/catenax-ng/tx-portal-assets',
+    DOCBASE: 'https://raw.githubusercontent.com/eclipse-tractusx/portal-assets',
+    SRCBASE: 'https://github.com/eclipse-tractusx/portal-assets',
     DEFAULT_ROOT: 'docs',
 }
 

--- a/src/documentation/Release.js
+++ b/src/documentation/Release.js
@@ -73,8 +73,8 @@ const createReleaseSelection = (version) => {
 
     const Settings = {
         BASE: 'https://api.github.com',
-        OWNER: 'catenax-ng',
-        REPO: 'tx-portal-assets',
+        OWNER: 'eclipse-tractusx',
+        REPO: 'portal-assets',
     }
 
     const url = `${Settings.BASE}/repos/${Settings.OWNER}/${Settings.REPO}/git/refs/tags`


### PR DESCRIPTION
## Description

Load data from eclipse repo

## Why

After the move of the container registry, the release process does occur exclusively in the tractusx GH org, due to that, the documentation pages must be loaded from the version tag in tractusx.

## Issue

N/A

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally