### PR TITLE
chore(workflows): add dependencies check and update release

### DIFF
--- a/.github/workflows/dependencies.yaml
+++ b/.github/workflows/dependencies.yaml
@@ -1,0 +1,79 @@
+###############################################################
+# Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+###############################################################
+
+name: Check Dependencies
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+
+jobs:
+  check-dependencies:
+
+    runs-on: ubuntu-latest
+
+    steps:
+  
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Generate Dependencies file
+        run: java -jar ./scripts/download/org.eclipse.dash.licenses-1.0.3-SNAPSHOT.jar yarn.lock -project automotive.tractusx -summary DEPENDENCIES
+
+      - name: Check if dependencies were changed
+        id: dependencies-changed
+        run: |
+          changed=$(git diff DEPENDENCIES)
+          if [[ -n "$changed" ]]; then
+            echo "dependencies changed"
+            echo "changed=true" >> $GITHUB_OUTPUT
+          else
+            echo "dependencies not changed"
+            echo "changed=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Check for restricted dependencies
+        run: |
+          restricted=$(grep ' restricted,' DEPENDENCIES || true)
+          if [[ -n "$restricted" ]]; then
+            echo "The following dependencies are restricted: $restricted"
+            exit 1
+          fi
+        if: steps.dependencies-changed.outputs.changed == 'true'
+
+      - name: Upload DEPENDENCIES file
+        uses: actions/upload-artifact@v3
+        with:
+          path: DEPENDENCIES
+        if: steps.dependencies-changed.outputs.changed == 'true'
+
+      - name: Signal need to update DEPENDENCIES
+        run: |
+          echo "Dependencies need to be updated (updated DEPENDENCIES file has been uploaded to workflow run)"
+          exit 1
+        if: steps.dependencies-changed.outputs.changed == 'true'

--- a/.github/workflows/dependencies.yaml
+++ b/.github/workflows/dependencies.yaml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Generate Dependencies file
-        run: java -jar ./scripts/download/org.eclipse.dash.licenses-1.0.3-SNAPSHOT.jar yarn.lock -project automotive.tractusx -summary DEPENDENCIES
+        run: java -jar ./scripts/download/org.eclipse.dash.licenses-1.0.2.jar yarn.lock -project automotive.tractusx -summary DEPENDENCIES
 
       - name: Check if dependencies were changed
         id: dependencies-changed

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,8 +121,19 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
+      - name: Check for hotfix version
+        id: hf-check
+        run: |
+          hf=$(git ls-remote --heads origin "hotfix/${{ env.REF_NAME }}*")
+          if [[ -n "$hf" ]]; then
+            echo "hf=true" >> $GITHUB_OUTPUT
+          else
+            echo "hf=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Get tags
         run: git fetch --tags --force
+        if: steps.hf-check.outputs.hf == 'false'
 
       - name: Check for previous release candidate version
         id: rc-check
@@ -130,7 +141,10 @@ jobs:
           rc=$(git tag -l "${{ env.REF_NAME }}-RC*")
           if [[ -n "$rc" ]]; then
             echo "rc=true" >> $GITHUB_OUTPUT
+          else
+            echo "rc=false" >> $GITHUB_OUTPUT
           fi
+        if: steps.hf-check.outputs.hf == 'false'
 
       - name: Determine branch to update in portal-cd
         id: cd-branch
@@ -140,6 +154,7 @@ jobs:
           else
             echo "branch=dev" >> $GITHUB_OUTPUT
           fi
+        if: steps.hf-check.outputs.hf == 'false'
 
       - name: Get token
         id: get_workflow_token
@@ -147,6 +162,7 @@ jobs:
         with:
           application_id: ${{ secrets.ORG_PORTAL_DISPATCH_APPID }}
           application_private_key: ${{ secrets.ORG_PORTAL_DISPATCH_KEY }}
+        if: steps.hf-check.outputs.hf == 'false'
 
       - name: Trigger workflow
         id: call_action
@@ -160,3 +176,4 @@ jobs:
             --header "Accept: application/vnd.github.v3+json" \
             --data '{"ref":"${{ steps.cd-branch.outputs.branch }}", "inputs": { "new-image":"${{ env.REF_NAME }}" }}' \
             --fail
+        if: steps.hf-check.outputs.hf == 'false'

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -1,491 +1,143 @@
-yarn licenses v1.5.1
-├─ (WTFPL OR MIT)
-│  └─ opener@1.5.2
-│     ├─ URL: https://github.com/domenic/opener.git
-│     ├─ VendorName: Domenic Denicola
-│     └─ VendorUrl: https://domenic.me/
-├─ 0BSD
-│  └─ tslib@2.5.2
-│     ├─ URL: https://github.com/Microsoft/tslib.git
-│     ├─ VendorName: Microsoft Corp.
-│     └─ VendorUrl: https://www.typescriptlang.org/
-├─ Apache-2.0
-│  └─ rxjs@7.8.1
-│     ├─ URL: https://github.com/reactivex/rxjs.git
-│     ├─ VendorName: Ben Lesh
-│     └─ VendorUrl: https://rxjs.dev/
-├─ BSD-3-Clause
-│  ├─ qs@6.11.0
-│  │  ├─ URL: https://github.com/ljharb/qs.git
-│  │  └─ VendorUrl: https://github.com/ljharb/qs
-│  └─ qs@6.11.2
-│     ├─ URL: https://github.com/ljharb/qs.git
-│     └─ VendorUrl: https://github.com/ljharb/qs
-├─ ISC
-│  ├─ cliui@8.0.1
-│  │  ├─ URL: https://github.com/yargs/cliui.git
-│  │  └─ VendorName: Ben Coe
-│  ├─ get-caller-file@2.0.5
-│  │  ├─ URL: git+https://github.com/stefanpenner/get-caller-file.git
-│  │  ├─ VendorName: Stefan Penner
-│  │  └─ VendorUrl: https://github.com/stefanpenner/get-caller-file#readme
-│  ├─ inherits@2.0.4
-│  │  └─ URL: git://github.com/isaacs/inherits
-│  ├─ setprototypeof@1.2.0
-│  │  ├─ URL: https://github.com/wesleytodd/setprototypeof.git
-│  │  ├─ VendorName: Wes Todd
-│  │  └─ VendorUrl: https://github.com/wesleytodd/setprototypeof
-│  ├─ y18n@5.0.8
-│  │  ├─ URL: https://github.com/yargs/y18n.git
-│  │  ├─ VendorName: Ben Coe
-│  │  └─ VendorUrl: https://github.com/yargs/y18n
-│  ├─ yargs-parser@21.1.1
-│  │  ├─ URL: https://github.com/yargs/yargs-parser.git
-│  │  └─ VendorName: Ben Coe
-│  └─ zero-md@2.4.1
-│     ├─ URL: https://github.com/zerodevx/zero-md.git
-│     ├─ VendorName: Jason Lee
-│     └─ VendorUrl: https://zerodevx.github.io/zero-md/
-└─ MIT
-   ├─ @babel/runtime@7.21.5
-   │  ├─ URL: https://github.com/babel/babel.git
-   │  ├─ VendorName: The Babel Team
-   │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-runtime
-   ├─ @types/http-proxy@1.17.11
-   │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-   │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/http-proxy
-   ├─ @types/node@20.2.3
-   │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-   │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/node
-   ├─ accepts@1.3.8
-   │  └─ URL: https://github.com/jshttp/accepts.git
-   ├─ ansi-regex@5.0.1
-   │  ├─ URL: https://github.com/chalk/ansi-regex.git
-   │  ├─ VendorName: Sindre Sorhus
-   │  └─ VendorUrl: sindresorhus.com
-   ├─ ansi-styles@3.2.1
-   │  ├─ URL: https://github.com/chalk/ansi-styles.git
-   │  ├─ VendorName: Sindre Sorhus
-   │  └─ VendorUrl: sindresorhus.com
-   ├─ ansi-styles@4.3.0
-   │  ├─ URL: https://github.com/chalk/ansi-styles.git
-   │  ├─ VendorName: Sindre Sorhus
-   │  └─ VendorUrl: sindresorhus.com
-   ├─ array-back@3.1.0
-   │  ├─ URL: https://github.com/75lb/array-back.git
-   │  └─ VendorName: Lloyd Brookes
-   ├─ array-back@4.0.2
-   │  ├─ URL: https://github.com/75lb/array-back.git
-   │  └─ VendorName: Lloyd Brookes
-   ├─ array-flatten@1.1.1
-   │  ├─ URL: git://github.com/blakeembrey/array-flatten.git
-   │  ├─ VendorName: Blake Embrey
-   │  └─ VendorUrl: https://github.com/blakeembrey/array-flatten
-   ├─ async@2.6.4
-   │  ├─ URL: https://github.com/caolan/async.git
-   │  ├─ VendorName: Caolan McMahon
-   │  └─ VendorUrl: https://caolan.github.io/async/
-   ├─ basic-auth@2.0.1
-   │  └─ URL: https://github.com/jshttp/basic-auth.git
-   ├─ body-parser@1.20.1
-   │  └─ URL: https://github.com/expressjs/body-parser.git
-   ├─ braces@3.0.2
-   │  ├─ URL: https://github.com/micromatch/braces.git
-   │  ├─ VendorName: Jon Schlinkert
-   │  └─ VendorUrl: https://github.com/micromatch/braces
-   ├─ bytes@3.1.2
-   │  ├─ URL: https://github.com/visionmedia/bytes.js.git
-   │  ├─ VendorName: TJ Holowaychuk
-   │  └─ VendorUrl: http://tjholowaychuk.com
-   ├─ call-bind@1.0.2
-   │  ├─ URL: git+https://github.com/ljharb/call-bind.git
-   │  ├─ VendorName: Jordan Harband
-   │  └─ VendorUrl: https://github.com/ljharb/call-bind#readme
-   ├─ chalk@2.4.2
-   │  └─ URL: https://github.com/chalk/chalk.git
-   ├─ chalk@4.1.2
-   │  └─ URL: https://github.com/chalk/chalk.git
-   ├─ color-convert@1.9.3
-   │  ├─ URL: https://github.com/Qix-/color-convert.git
-   │  └─ VendorName: Heather Arthur
-   ├─ color-convert@2.0.1
-   │  ├─ URL: https://github.com/Qix-/color-convert.git
-   │  └─ VendorName: Heather Arthur
-   ├─ color-name@1.1.3
-   │  ├─ URL: git@github.com:dfcreative/color-name.git
-   │  ├─ VendorName: DY
-   │  └─ VendorUrl: https://github.com/dfcreative/color-name
-   ├─ color-name@1.1.4
-   │  ├─ URL: git@github.com:colorjs/color-name.git
-   │  ├─ VendorName: DY
-   │  └─ VendorUrl: https://github.com/colorjs/color-name
-   ├─ command-line-args@5.2.1
-   │  ├─ URL: https://github.com/75lb/command-line-args
-   │  └─ VendorName: Lloyd Brookes
-   ├─ command-line-usage@6.1.3
-   │  ├─ URL: https://github.com/75lb/command-line-usage
-   │  └─ VendorName: Lloyd Brookes
-   ├─ concurrently@8.1.0
-   │  ├─ URL: https://github.com/open-cli-tools/concurrently.git
-   │  └─ VendorName: Kimmo Brunfeldt
-   ├─ content-disposition@0.5.4
-   │  ├─ URL: https://github.com/jshttp/content-disposition.git
-   │  └─ VendorName: Douglas Christopher Wilson
-   ├─ content-type@1.0.5
-   │  ├─ URL: https://github.com/jshttp/content-type.git
-   │  └─ VendorName: Douglas Christopher Wilson
-   ├─ cookie-signature@1.0.6
-   │  ├─ URL: https://github.com/visionmedia/node-cookie-signature.git
-   │  └─ VendorName: TJ Holowaychuk
-   ├─ cookie@0.5.0
-   │  ├─ URL: https://github.com/jshttp/cookie.git
-   │  └─ VendorName: Roman Shtylman
-   ├─ corser@2.0.1
-   │  ├─ URL: https://github.com/agrueneberg/Corser.git
-   │  └─ VendorName: Alexander Grüneberg
-   ├─ date-fns@2.30.0
-   │  └─ URL: https://github.com/date-fns/date-fns
-   ├─ debug@2.6.9
-   │  ├─ URL: git://github.com/visionmedia/debug.git
-   │  └─ VendorName: TJ Holowaychuk
-   ├─ debug@3.2.7
-   │  ├─ URL: git://github.com/visionmedia/debug.git
-   │  └─ VendorName: TJ Holowaychuk
-   ├─ deep-extend@0.6.0
-   │  ├─ URL: git://github.com/unclechu/node-deep-extend.git
-   │  ├─ VendorName: Viacheslav Lotsmanov
-   │  └─ VendorUrl: https://github.com/unclechu/node-deep-extend
-   ├─ depd@2.0.0
-   │  ├─ URL: https://github.com/dougwilson/nodejs-depd.git
-   │  └─ VendorName: Douglas Christopher Wilson
-   ├─ destroy@1.2.0
-   │  ├─ URL: https://github.com/stream-utils/destroy.git
-   │  ├─ VendorName: Jonathan Ong
-   │  └─ VendorUrl: http://jongleberry.com
-   ├─ directory-tree@3.5.1
-   │  ├─ URL: https://github.com/mihneadb/node-directory-tree
-   │  ├─ VendorName: Mihnea Dobrescu-Balaur
-   │  └─ VendorUrl: https://github.com/mihneadb/node-directory-tree
-   ├─ ee-first@1.1.1
-   │  ├─ URL: https://github.com/jonathanong/ee-first.git
-   │  ├─ VendorName: Jonathan Ong
-   │  └─ VendorUrl: http://jongleberry.com
-   ├─ emoji-regex@8.0.0
-   │  ├─ URL: https://github.com/mathiasbynens/emoji-regex.git
-   │  ├─ VendorName: Mathias Bynens
-   │  └─ VendorUrl: https://mths.be/emoji-regex
-   ├─ encodeurl@1.0.2
-   │  └─ URL: https://github.com/pillarjs/encodeurl.git
-   ├─ escalade@3.1.1
-   │  ├─ URL: https://github.com/lukeed/escalade.git
-   │  ├─ VendorName: Luke Edwards
-   │  └─ VendorUrl: https://lukeed.com
-   ├─ escape-html@1.0.3
-   │  └─ URL: https://github.com/component/escape-html.git
-   ├─ escape-string-regexp@1.0.5
-   │  ├─ URL: https://github.com/sindresorhus/escape-string-regexp.git
-   │  ├─ VendorName: Sindre Sorhus
-   │  └─ VendorUrl: sindresorhus.com
-   ├─ etag@1.8.1
-   │  └─ URL: https://github.com/jshttp/etag.git
-   ├─ eventemitter3@4.0.7
-   │  ├─ URL: git://github.com/primus/eventemitter3.git
-   │  └─ VendorName: Arnout Kazemier
-   ├─ express@4.18.2
-   │  ├─ URL: https://github.com/expressjs/express.git
-   │  ├─ VendorName: TJ Holowaychuk
-   │  └─ VendorUrl: http://expressjs.com/
-   ├─ fill-range@7.0.1
-   │  ├─ URL: https://github.com/jonschlinkert/fill-range.git
-   │  ├─ VendorName: Jon Schlinkert
-   │  └─ VendorUrl: https://github.com/jonschlinkert/fill-range
-   ├─ finalhandler@1.2.0
-   │  ├─ URL: https://github.com/pillarjs/finalhandler.git
-   │  └─ VendorName: Douglas Christopher Wilson
-   ├─ find-replace@3.0.0
-   │  ├─ URL: https://github.com/75lb/find-replace.git
-   │  └─ VendorName: Lloyd Brookes
-   ├─ follow-redirects@1.15.2
-   │  ├─ URL: git@github.com:follow-redirects/follow-redirects.git
-   │  ├─ VendorName: Ruben Verborgh
-   │  └─ VendorUrl: https://github.com/follow-redirects/follow-redirects
-   ├─ forwarded@0.2.0
-   │  └─ URL: https://github.com/jshttp/forwarded.git
-   ├─ fresh@0.5.2
-   │  ├─ URL: https://github.com/jshttp/fresh.git
-   │  ├─ VendorName: TJ Holowaychuk
-   │  └─ VendorUrl: http://tjholowaychuk.com
-   ├─ function-bind@1.1.1
-   │  ├─ URL: git://github.com/Raynos/function-bind.git
-   │  ├─ VendorName: Raynos
-   │  └─ VendorUrl: https://github.com/Raynos/function-bind
-   ├─ get-intrinsic@1.2.1
-   │  ├─ URL: git+https://github.com/ljharb/get-intrinsic.git
-   │  ├─ VendorName: Jordan Harband
-   │  └─ VendorUrl: https://github.com/ljharb/get-intrinsic#readme
-   ├─ has-flag@3.0.0
-   │  ├─ URL: https://github.com/sindresorhus/has-flag.git
-   │  ├─ VendorName: Sindre Sorhus
-   │  └─ VendorUrl: sindresorhus.com
-   ├─ has-flag@4.0.0
-   │  ├─ URL: https://github.com/sindresorhus/has-flag.git
-   │  ├─ VendorName: Sindre Sorhus
-   │  └─ VendorUrl: sindresorhus.com
-   ├─ has-proto@1.0.1
-   │  ├─ URL: git+https://github.com/inspect-js/has-proto.git
-   │  ├─ VendorName: Jordan Harband
-   │  └─ VendorUrl: https://github.com/inspect-js/has-proto#readme
-   ├─ has-symbols@1.0.3
-   │  ├─ URL: git://github.com/inspect-js/has-symbols.git
-   │  ├─ VendorName: Jordan Harband
-   │  └─ VendorUrl: https://github.com/ljharb/has-symbols#readme
-   ├─ has@1.0.3
-   │  ├─ URL: git://github.com/tarruda/has.git
-   │  ├─ VendorName: Thiago de Arruda
-   │  └─ VendorUrl: https://github.com/tarruda/has
-   ├─ he@1.2.0
-   │  ├─ URL: https://github.com/mathiasbynens/he.git
-   │  ├─ VendorName: Mathias Bynens
-   │  └─ VendorUrl: https://mths.be/he
-   ├─ html-encoding-sniffer@3.0.0
-   │  ├─ URL: https://github.com/jsdom/html-encoding-sniffer.git
-   │  ├─ VendorName: Domenic Denicola
-   │  └─ VendorUrl: https://domenic.me/
-   ├─ http-errors@2.0.0
-   │  ├─ URL: https://github.com/jshttp/http-errors.git
-   │  ├─ VendorName: Jonathan Ong
-   │  └─ VendorUrl: http://jongleberry.com
-   ├─ http-proxy-middleware@2.0.6
-   │  ├─ URL: https://github.com/chimurai/http-proxy-middleware.git
-   │  ├─ VendorName: Steven Chim
-   │  └─ VendorUrl: https://github.com/chimurai/http-proxy-middleware#readme
-   ├─ http-proxy@1.18.1
-   │  ├─ URL: https://github.com/http-party/node-http-proxy.git
-   │  └─ VendorName: Charlie Robbins
-   ├─ http-server@14.1.1
-   │  └─ URL: git://github.com/http-party/http-server.git
-   ├─ iconv-lite@0.4.24
-   │  ├─ URL: git://github.com/ashtuchkin/iconv-lite.git
-   │  ├─ VendorName: Alexander Shtuchkin
-   │  └─ VendorUrl: https://github.com/ashtuchkin/iconv-lite
-   ├─ iconv-lite@0.6.3
-   │  ├─ URL: git://github.com/ashtuchkin/iconv-lite.git
-   │  ├─ VendorName: Alexander Shtuchkin
-   │  └─ VendorUrl: https://github.com/ashtuchkin/iconv-lite
-   ├─ ipaddr.js@1.9.1
-   │  ├─ URL: git://github.com/whitequark/ipaddr.js
-   │  └─ VendorName: whitequark
-   ├─ is-extglob@2.1.1
-   │  ├─ URL: https://github.com/jonschlinkert/is-extglob.git
-   │  ├─ VendorName: Jon Schlinkert
-   │  └─ VendorUrl: https://github.com/jonschlinkert/is-extglob
-   ├─ is-fullwidth-code-point@3.0.0
-   │  ├─ URL: https://github.com/sindresorhus/is-fullwidth-code-point.git
-   │  ├─ VendorName: Sindre Sorhus
-   │  └─ VendorUrl: sindresorhus.com
-   ├─ is-glob@4.0.3
-   │  ├─ URL: https://github.com/micromatch/is-glob.git
-   │  ├─ VendorName: Jon Schlinkert
-   │  └─ VendorUrl: https://github.com/micromatch/is-glob
-   ├─ is-number@7.0.0
-   │  ├─ URL: https://github.com/jonschlinkert/is-number.git
-   │  ├─ VendorName: Jon Schlinkert
-   │  └─ VendorUrl: https://github.com/jonschlinkert/is-number
-   ├─ is-plain-obj@3.0.0
-   │  ├─ URL: https://github.com/sindresorhus/is-plain-obj.git
-   │  ├─ VendorName: Sindre Sorhus
-   │  └─ VendorUrl: https://sindresorhus.com
-   ├─ lodash.camelcase@4.3.0
-   │  ├─ URL: https://github.com/lodash/lodash.git
-   │  ├─ VendorName: John-David Dalton
-   │  └─ VendorUrl: https://lodash.com/
-   ├─ lodash@4.17.21
-   │  ├─ URL: https://github.com/lodash/lodash.git
-   │  ├─ VendorName: John-David Dalton
-   │  └─ VendorUrl: https://lodash.com/
-   ├─ media-typer@0.3.0
-   │  ├─ URL: https://github.com/jshttp/media-typer.git
-   │  └─ VendorName: Douglas Christopher Wilson
-   ├─ merge-descriptors@1.0.1
-   │  ├─ URL: https://github.com/component/merge-descriptors.git
-   │  ├─ VendorName: Jonathan Ong
-   │  └─ VendorUrl: http://jongleberry.com
-   ├─ methods@1.1.2
-   │  └─ URL: https://github.com/jshttp/methods.git
-   ├─ micromatch@4.0.5
-   │  ├─ URL: https://github.com/micromatch/micromatch.git
-   │  ├─ VendorName: Jon Schlinkert
-   │  └─ VendorUrl: https://github.com/micromatch/micromatch
-   ├─ mime-db@1.52.0
-   │  └─ URL: https://github.com/jshttp/mime-db.git
-   ├─ mime-types@2.1.35
-   │  └─ URL: https://github.com/jshttp/mime-types.git
-   ├─ mime@1.6.0
-   │  ├─ URL: https://github.com/broofa/node-mime
-   │  ├─ VendorName: Robert Kieffer
-   │  └─ VendorUrl: http://github.com/broofa
-   ├─ minimist@1.2.8
-   │  ├─ URL: git://github.com/minimistjs/minimist.git
-   │  ├─ VendorName: James Halliday
-   │  └─ VendorUrl: https://github.com/minimistjs/minimist
-   ├─ mkdirp@0.5.6
-   │  ├─ URL: https://github.com/substack/node-mkdirp.git
-   │  ├─ VendorName: James Halliday
-   │  └─ VendorUrl: http://substack.net
-   ├─ ms@2.0.0
-   │  └─ URL: https://github.com/zeit/ms.git
-   ├─ ms@2.1.3
-   │  └─ URL: https://github.com/vercel/ms.git
-   ├─ negotiator@0.6.3
-   │  └─ URL: https://github.com/jshttp/negotiator.git
-   ├─ object-inspect@1.12.3
-   │  ├─ URL: git://github.com/inspect-js/object-inspect.git
-   │  ├─ VendorName: James Halliday
-   │  └─ VendorUrl: https://github.com/inspect-js/object-inspect
-   ├─ on-finished@2.4.1
-   │  └─ URL: https://github.com/jshttp/on-finished.git
-   ├─ parseurl@1.3.3
-   │  └─ URL: https://github.com/pillarjs/parseurl.git
-   ├─ path-to-regexp@0.1.7
-   │  └─ URL: https://github.com/component/path-to-regexp.git
-   ├─ picomatch@2.3.1
-   │  ├─ URL: https://github.com/micromatch/picomatch.git
-   │  ├─ VendorName: Jon Schlinkert
-   │  └─ VendorUrl: https://github.com/micromatch/picomatch
-   ├─ portfinder@1.0.32
-   │  ├─ URL: git@github.com:http-party/node-portfinder.git
-   │  └─ VendorName: Charlie Robbins
-   ├─ proxy-addr@2.0.7
-   │  ├─ URL: https://github.com/jshttp/proxy-addr.git
-   │  └─ VendorName: Douglas Christopher Wilson
-   ├─ range-parser@1.2.1
-   │  ├─ URL: https://github.com/jshttp/range-parser.git
-   │  ├─ VendorName: TJ Holowaychuk
-   │  └─ VendorUrl: http://tjholowaychuk.com
-   ├─ raw-body@2.5.1
-   │  ├─ URL: https://github.com/stream-utils/raw-body.git
-   │  ├─ VendorName: Jonathan Ong
-   │  └─ VendorUrl: http://jongleberry.com
-   ├─ reduce-flatten@2.0.0
-   │  ├─ URL: https://github.com/75lb/reduce-flatten.git
-   │  └─ VendorName: Lloyd Brookes
-   ├─ regenerator-runtime@0.13.11
-   │  ├─ URL: https://github.com/facebook/regenerator/tree/main/packages/runtime
-   │  └─ VendorName: Ben Newman
-   ├─ require-directory@2.1.1
-   │  ├─ URL: git://github.com/troygoode/node-require-directory.git
-   │  ├─ VendorName: Troy Goode
-   │  └─ VendorUrl: https://github.com/troygoode/node-require-directory/
-   ├─ requires-port@1.0.0
-   │  ├─ URL: https://github.com/unshiftio/requires-port
-   │  ├─ VendorName: Arnout Kazemier
-   │  └─ VendorUrl: https://github.com/unshiftio/requires-port
-   ├─ safe-buffer@5.1.2
-   │  ├─ URL: git://github.com/feross/safe-buffer.git
-   │  ├─ VendorName: Feross Aboukhadijeh
-   │  └─ VendorUrl: https://github.com/feross/safe-buffer
-   ├─ safe-buffer@5.2.1
-   │  ├─ URL: git://github.com/feross/safe-buffer.git
-   │  ├─ VendorName: Feross Aboukhadijeh
-   │  └─ VendorUrl: https://github.com/feross/safe-buffer
-   ├─ safer-buffer@2.1.2
-   │  ├─ URL: git+https://github.com/ChALkeR/safer-buffer.git
-   │  ├─ VendorName: Nikita Skovoroda
-   │  └─ VendorUrl: https://github.com/ChALkeR
-   ├─ secure-compare@3.0.1
-   │  ├─ URL: https://github.com/vdemedes/secure-compare.git
-   │  ├─ VendorName: Vadim Demedes
-   │  └─ VendorUrl: https://github.com/vdemedes/secure-compare
-   ├─ send@0.18.0
-   │  ├─ URL: https://github.com/pillarjs/send.git
-   │  └─ VendorName: TJ Holowaychuk
-   ├─ serve-static@1.15.0
-   │  ├─ URL: https://github.com/expressjs/serve-static.git
-   │  └─ VendorName: Douglas Christopher Wilson
-   ├─ shell-quote@1.8.1
-   │  ├─ URL: http://github.com/ljharb/shell-quote.git
-   │  ├─ VendorName: James Halliday
-   │  └─ VendorUrl: https://github.com/ljharb/shell-quote
-   ├─ side-channel@1.0.4
-   │  ├─ URL: git+https://github.com/ljharb/side-channel.git
-   │  ├─ VendorName: Jordan Harband
-   │  └─ VendorUrl: https://github.com/ljharb/side-channel#readme
-   ├─ spawn-command@0.0.2-1
-   │  ├─ URL: https://github.com/mmalecki/spawn-command
-   │  └─ VendorName: Maciej Małecki
-   ├─ statuses@2.0.1
-   │  └─ URL: https://github.com/jshttp/statuses.git
-   ├─ string-width@4.2.3
-   │  ├─ URL: https://github.com/sindresorhus/string-width.git
-   │  ├─ VendorName: Sindre Sorhus
-   │  └─ VendorUrl: sindresorhus.com
-   ├─ strip-ansi@6.0.1
-   │  ├─ URL: https://github.com/chalk/strip-ansi.git
-   │  ├─ VendorName: Sindre Sorhus
-   │  └─ VendorUrl: sindresorhus.com
-   ├─ supports-color@5.5.0
-   │  ├─ URL: https://github.com/chalk/supports-color.git
-   │  ├─ VendorName: Sindre Sorhus
-   │  └─ VendorUrl: sindresorhus.com
-   ├─ supports-color@7.2.0
-   │  ├─ URL: https://github.com/chalk/supports-color.git
-   │  ├─ VendorName: Sindre Sorhus
-   │  └─ VendorUrl: sindresorhus.com
-   ├─ supports-color@8.1.1
-   │  ├─ URL: https://github.com/chalk/supports-color.git
-   │  ├─ VendorName: Sindre Sorhus
-   │  └─ VendorUrl: https://sindresorhus.com
-   ├─ table-layout@1.0.2
-   │  ├─ URL: https://github.com/75lb/table-layout.git
-   │  └─ VendorName: Lloyd Brookes
-   ├─ to-regex-range@5.0.1
-   │  ├─ URL: https://github.com/micromatch/to-regex-range.git
-   │  ├─ VendorName: Jon Schlinkert
-   │  └─ VendorUrl: https://github.com/micromatch/to-regex-range
-   ├─ toidentifier@1.0.1
-   │  ├─ URL: https://github.com/component/toidentifier.git
-   │  └─ VendorName: Douglas Christopher Wilson
-   ├─ tree-kill@1.2.2
-   │  ├─ URL: git://github.com/pkrumins/node-tree-kill.git
-   │  ├─ VendorName: Peteris Krumins
-   │  └─ VendorUrl: https://github.com/pkrumins/node-tree-kill
-   ├─ type-is@1.6.18
-   │  └─ URL: https://github.com/jshttp/type-is.git
-   ├─ typical@4.0.0
-   │  ├─ URL: https://github.com/75lb/typical
-   │  └─ VendorName: Lloyd Brookes
-   ├─ typical@5.2.0
-   │  ├─ URL: https://github.com/75lb/typical
-   │  └─ VendorName: Lloyd Brookes
-   ├─ union@0.5.0
-   │  ├─ URL: http://github.com/flatiron/union.git
-   │  └─ VendorName: Charlie Robbins
-   ├─ unpipe@1.0.0
-   │  ├─ URL: https://github.com/stream-utils/unpipe.git
-   │  └─ VendorName: Douglas Christopher Wilson
-   ├─ url-join@4.0.1
-   │  ├─ URL: git://github.com/jfromaniello/url-join.git
-   │  ├─ VendorName: José F. Romaniello
-   │  └─ VendorUrl: http://joseoncode.com
-   ├─ utils-merge@1.0.1
-   │  ├─ URL: git://github.com/jaredhanson/utils-merge.git
-   │  ├─ VendorName: Jared Hanson
-   │  └─ VendorUrl: http://www.jaredhanson.net/
-   ├─ vary@1.1.2
-   │  ├─ URL: https://github.com/jshttp/vary.git
-   │  └─ VendorName: Douglas Christopher Wilson
-   ├─ whatwg-encoding@2.0.0
-   │  ├─ URL: https://github.com/jsdom/whatwg-encoding.git
-   │  ├─ VendorName: Domenic Denicola
-   │  └─ VendorUrl: https://domenic.me/
-   ├─ wordwrapjs@4.0.1
-   │  ├─ URL: https://github.com/75lb/wordwrapjs.git
-   │  └─ VendorName: Lloyd Brookes
-   ├─ wrap-ansi@7.0.0
-   │  ├─ URL: https://github.com/chalk/wrap-ansi.git
-   │  ├─ VendorName: Sindre Sorhus
-   │  └─ VendorUrl: https://sindresorhus.com
-   └─ yargs@17.7.2
-      ├─ URL: https://github.com/yargs/yargs.git
-      └─ VendorUrl: https://yargs.js.org/
-Done in 2.46s.
+npm/npmjs/-/accepts/1.3.8, MIT, approved, clearlydefined
+npm/npmjs/-/ansi-regex/5.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/ansi-styles/3.2.1, MIT, approved, clearlydefined
+npm/npmjs/-/ansi-styles/4.3.0, MIT, approved, clearlydefined
+npm/npmjs/-/array-back/3.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/array-back/4.0.2, MIT, approved, clearlydefined
+npm/npmjs/-/array-flatten/1.1.1, MIT, approved, clearlydefined
+npm/npmjs/-/async/2.6.4, MIT, approved, clearlydefined
+npm/npmjs/-/basic-auth/2.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/body-parser/1.20.1, MIT, approved, clearlydefined
+npm/npmjs/-/braces/3.0.2, MIT, approved, clearlydefined
+npm/npmjs/-/bytes/3.1.2, MIT, approved, clearlydefined
+npm/npmjs/-/call-bind/1.0.2, MIT, approved, clearlydefined
+npm/npmjs/-/chalk/2.4.2, MIT, approved, clearlydefined
+npm/npmjs/-/chalk/4.1.2, MIT, approved, clearlydefined
+npm/npmjs/-/cliui/8.0.1, ISC AND Artistic-2.0, approved, #3753
+npm/npmjs/-/color-convert/1.9.3, MIT, approved, clearlydefined
+npm/npmjs/-/color-convert/2.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/color-name/1.1.3, MIT, approved, clearlydefined
+npm/npmjs/-/color-name/1.1.4, MIT, approved, clearlydefined
+npm/npmjs/-/command-line-args/5.2.1, MIT, approved, clearlydefined
+npm/npmjs/-/command-line-usage/6.1.3, MIT, approved, clearlydefined
+npm/npmjs/-/concurrently/7.6.0, MIT, approved, clearlydefined
+npm/npmjs/-/content-disposition/0.5.4, MIT, approved, clearlydefined
+npm/npmjs/-/content-type/1.0.5, MIT, approved, #6950
+npm/npmjs/-/cookie-signature/1.0.6, MIT, approved, clearlydefined
+npm/npmjs/-/cookie/0.5.0, MIT, approved, clearlydefined
+npm/npmjs/-/corser/2.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/date-fns/2.30.0, MIT, approved, clearlydefined
+npm/npmjs/-/debug/2.6.9, MIT, approved, clearlydefined
+npm/npmjs/-/debug/3.2.7, MIT, approved, clearlydefined
+npm/npmjs/-/deep-extend/0.6.0, MIT, approved, clearlydefined
+npm/npmjs/-/depd/2.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/destroy/1.2.0, MIT, approved, clearlydefined
+npm/npmjs/-/directory-tree/3.5.1, MIT, approved, clearlydefined
+npm/npmjs/-/ee-first/1.1.1, MIT, approved, clearlydefined
+npm/npmjs/-/emoji-regex/8.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/encodeurl/1.0.2, MIT, approved, clearlydefined
+npm/npmjs/-/escalade/3.1.1, MIT, approved, clearlydefined
+npm/npmjs/-/escape-html/1.0.3, MIT, approved, clearlydefined
+npm/npmjs/-/escape-string-regexp/1.0.5, MIT, approved, clearlydefined
+npm/npmjs/-/etag/1.8.1, MIT, approved, clearlydefined
+npm/npmjs/-/eventemitter3/4.0.7, MIT, approved, clearlydefined
+npm/npmjs/-/express/4.18.2, MIT, approved, clearlydefined
+npm/npmjs/-/fill-range/7.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/finalhandler/1.2.0, MIT, approved, clearlydefined
+npm/npmjs/-/find-replace/3.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/follow-redirects/1.15.2, MIT, approved, clearlydefined
+npm/npmjs/-/forwarded/0.2.0, MIT, approved, clearlydefined
+npm/npmjs/-/fresh/0.5.2, MIT, approved, clearlydefined
+npm/npmjs/-/function-bind/1.1.1, MIT, approved, clearlydefined
+npm/npmjs/-/get-caller-file/2.0.5, ISC, approved, clearlydefined
+npm/npmjs/-/get-intrinsic/1.2.1, MIT, approved, #8453
+npm/npmjs/-/has-flag/3.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/has-flag/4.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/has-proto/1.0.1, MIT, approved, #6175
+npm/npmjs/-/has-symbols/1.0.3, MIT, approved, clearlydefined
+npm/npmjs/-/has/1.0.3, MIT, approved, clearlydefined
+npm/npmjs/-/he/1.2.0, MIT, approved, clearlydefined
+npm/npmjs/-/html-encoding-sniffer/3.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/http-errors/2.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/http-proxy-middleware/2.0.6, MIT, approved, clearlydefined
+npm/npmjs/-/http-proxy/1.18.1, MIT, approved, clearlydefined
+npm/npmjs/-/http-server/14.1.1, MIT, approved, clearlydefined
+npm/npmjs/-/iconv-lite/0.4.24, MIT, approved, clearlydefined
+npm/npmjs/-/iconv-lite/0.6.3, MIT, approved, clearlydefined
+npm/npmjs/-/inherits/2.0.4, ISC, approved, clearlydefined
+npm/npmjs/-/ipaddr.js/1.9.1, MIT, approved, clearlydefined
+npm/npmjs/-/is-extglob/2.1.1, MIT, approved, clearlydefined
+npm/npmjs/-/is-fullwidth-code-point/3.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/is-glob/4.0.3, MIT, approved, clearlydefined
+npm/npmjs/-/is-number/7.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/is-plain-obj/3.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/lodash.camelcase/4.3.0, MIT, approved, clearlydefined
+npm/npmjs/-/lodash/4.17.21, CC0-1.0 AND MIT, approved, #2096
+npm/npmjs/-/media-typer/0.3.0, MIT, approved, clearlydefined
+npm/npmjs/-/merge-descriptors/1.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/methods/1.1.2, MIT, approved, clearlydefined
+npm/npmjs/-/micromatch/4.0.5, MIT, approved, clearlydefined
+npm/npmjs/-/mime-db/1.52.0, MIT, approved, clearlydefined
+npm/npmjs/-/mime-types/2.1.35, MIT, approved, clearlydefined
+npm/npmjs/-/mime/1.6.0, MIT, approved, clearlydefined
+npm/npmjs/-/minimist/1.2.8, MIT, approved, #5886
+npm/npmjs/-/mkdirp/0.5.6, MIT, approved, clearlydefined
+npm/npmjs/-/ms/2.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/ms/2.1.3, MIT, approved, #5895
+npm/npmjs/-/negotiator/0.6.3, MIT, approved, clearlydefined
+npm/npmjs/-/object-inspect/1.12.3, MIT, approved, clearlydefined
+npm/npmjs/-/on-finished/2.4.1, MIT, approved, clearlydefined
+npm/npmjs/-/opener/1.5.2, MIT OR WTFPL OR (MIT AND WTFPL), approved, clearlydefined
+npm/npmjs/-/parseurl/1.3.3, MIT, approved, clearlydefined
+npm/npmjs/-/path-to-regexp/0.1.7, MIT, approved, clearlydefined
+npm/npmjs/-/picomatch/2.3.1, MIT, approved, clearlydefined
+npm/npmjs/-/portfinder/1.0.32, MIT, approved, clearlydefined
+npm/npmjs/-/proxy-addr/2.0.7, MIT, approved, clearlydefined
+npm/npmjs/-/qs/6.11.0, BSD-3-Clause, approved, #7556
+npm/npmjs/-/qs/6.11.2, BSD-3-Clause, approved, #7556
+npm/npmjs/-/range-parser/1.2.1, MIT, approved, clearlydefined
+npm/npmjs/-/raw-body/2.5.1, MIT, approved, clearlydefined
+npm/npmjs/-/reduce-flatten/2.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/regenerator-runtime/0.13.11, MIT, approved, #4978
+npm/npmjs/-/require-directory/2.1.1, MIT, approved, clearlydefined
+npm/npmjs/-/requires-port/1.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/rxjs/7.8.1, Apache-2.0 AND (0BSD AND Apache-2.0) AND 0BSD, approved, #5993
+npm/npmjs/-/safe-buffer/5.1.2, MIT, approved, clearlydefined
+npm/npmjs/-/safe-buffer/5.2.1, MIT, approved, clearlydefined
+npm/npmjs/-/safer-buffer/2.1.2, MIT, approved, clearlydefined
+npm/npmjs/-/secure-compare/3.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/send/0.18.0, MIT, approved, clearlydefined
+npm/npmjs/-/serve-static/1.15.0, MIT, approved, clearlydefined
+npm/npmjs/-/setprototypeof/1.2.0, ISC, approved, clearlydefined
+npm/npmjs/-/shell-quote/1.8.1, MIT, approved, #7044
+npm/npmjs/-/side-channel/1.0.4, MIT, approved, clearlydefined
+npm/npmjs/-/spawn-command/0.0.2-1, MIT, approved, #266
+npm/npmjs/-/statuses/2.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/string-width/4.2.3, MIT, approved, clearlydefined
+npm/npmjs/-/strip-ansi/6.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/supports-color/5.5.0, MIT, approved, clearlydefined
+npm/npmjs/-/supports-color/7.2.0, MIT, approved, clearlydefined
+npm/npmjs/-/supports-color/8.1.1, MIT, approved, clearlydefined
+npm/npmjs/-/table-layout/1.0.2, MIT, approved, clearlydefined
+npm/npmjs/-/to-regex-range/5.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/toidentifier/1.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/tree-kill/1.2.2, MIT, approved, clearlydefined
+npm/npmjs/-/tslib/2.5.2, 0BSD, approved, #6747
+npm/npmjs/-/type-is/1.6.18, MIT, approved, clearlydefined
+npm/npmjs/-/typical/4.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/typical/5.2.0, MIT, approved, clearlydefined
+npm/npmjs/-/union/0.5.0, MIT, approved, clearlydefined
+npm/npmjs/-/unpipe/1.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/url-join/4.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/utils-merge/1.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/vary/1.1.2, MIT, approved, clearlydefined
+npm/npmjs/-/whatwg-encoding/2.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/wordwrapjs/4.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/wrap-ansi/7.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/y18n/5.0.8, ISC, approved, clearlydefined
+npm/npmjs/-/yargs-parser/21.1.1, ISC, approved, clearlydefined
+npm/npmjs/-/yargs/17.7.2, MIT, approved, #8222
+npm/npmjs/-/zero-md/2.4.1, ISC, approved, #7067
+npm/npmjs/@babel/runtime/7.21.5, MIT AND (BSD-2-Clause AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #7349
+npm/npmjs/@types/http-proxy/1.17.11, MIT, approved, #8414
+npm/npmjs/@types/node/20.2.3, MIT, approved, clearlydefined

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -22,12 +22,13 @@ SPDX-License-Identifier: Apache-2.0
 
 The project maintains the following source code repositories in the GitHub organization https://github.com/eclipse-tractusx:
 
-* https://github.com/eclipse-tractusx/portal-frontend-registration
-* https://github.com/eclipse-tractusx/portal-frontend
-* https://github.com/eclipse-tractusx/portal-backend
-* https://github.com/eclipse-tractusx/portal-assets
-* https://github.com/eclipse-tractusx/portal-cd
-* https://github.com/eclipse-tractusx/portal-iam
+- https://github.com/eclipse-tractusx/portal-frontend-registration
+- https://github.com/eclipse-tractusx/portal-frontend
+- https://github.com/eclipse-tractusx/portal-shared-components
+- https://github.com/eclipse-tractusx/portal-backend
+- https://github.com/eclipse-tractusx/portal-assets
+- https://github.com/eclipse-tractusx/portal-cd
+- https://github.com/eclipse-tractusx/portal-iam
 
 ## Third-party Content
 

--- a/scripts/check-dependencies.md
+++ b/scripts/check-dependencies.md
@@ -6,4 +6,4 @@ This workflow uses the executable jar in the download directory.
 
 In order to update the executable jar run the following command from the root directory:
 
-    curl -L --output ./scripts/download/org.eclipse.dash.licenses-1.0.3-SNAPSHOT.jar 'https://repo.eclipse.org/service/local/artifact/maven/redirect?r=dash-licenses&g=org.eclipse.dash&a=org.eclipse.dash.licenses&v=1.0.3-SNAPSHOT'
+    curl -L --output ./scripts/download/org.eclipse.dash.licenses-1.0.2.jar 'https://repo.eclipse.org/service/local/artifact/maven/redirect?r=dash-licenses&g=org.eclipse.dash&a=org.eclipse.dash.licenses&v=1.0.2'

--- a/scripts/check-dependencies.md
+++ b/scripts/check-dependencies.md
@@ -1,0 +1,9 @@
+# Check dependencies
+
+Dependencies are checked by the [Eclipse Dash License Tool](https://github.com/eclipse/dash-licenses) with a GitHub workflow (dependencies.yaml).
+
+This workflow uses the executable jar in the download directory.
+
+In order to update the executable jar run the following command from the root directory:
+
+    curl -L --output ./scripts/download/org.eclipse.dash.licenses-1.0.3-SNAPSHOT.jar 'https://repo.eclipse.org/service/local/artifact/maven/redirect?r=dash-licenses&g=org.eclipse.dash&a=org.eclipse.dash.licenses&v=1.0.3-SNAPSHOT'


### PR DESCRIPTION
## Description

- add workflow to check 3rd party dependencies with the [Eclipse Dash License Tool](https://github.com/eclipse/dash-licenses)
- change dependencies file to '-summary' format from Dash Tool

**Due to the new format in the dependencies file: once this PR is merged into dev, all open feature branches should be rebased to dev, as the dependencies check will fail otherwise.**

- skip dispatch to portal-cd for hotfix in the release workflow
- update notice file

## Why

Dependencies check should be automated
Hotfix scenario not yet covered by release workflow
Notice file needs to be update due to new shared components repository

## Issue

n/a

## Checklist

Please delete options that are not relevant.

- [x] I have performed a self-review of my own changes
- [x] I have successfully tested my changes locally
