### PR TITLE
bugfix(help side menu): fix scroll height

### DIFF
--- a/public/documentation/css/Chapter.css
+++ b/public/documentation/css/Chapter.css
@@ -41,7 +41,8 @@ nav.menu {
     display: flex;
     flex-direction: row;
     transition: width 0.1s;
-    min-height: 35vh;
+    height: 75vh;
+    overflow-y: scroll;
 }
 
 nav.menu.open {
@@ -49,7 +50,7 @@ nav.menu.open {
 }
 
 nav.menu.open ul.level1 {
-    max-height: calc(100vh - 190px);
+    max-height: calc(100vh - 10px);
 }
 
 nav.menu.open .home {
@@ -61,6 +62,7 @@ nav.menu.open .scroller {
     width: 100%;
     margin-top: 76px;
     position: relative;
+    height: 100%;
 }
 
 nav.menu.closed,
@@ -95,6 +97,7 @@ nav.menu button.scroll:first-of-type {
 
 nav.menu button.scroll:last-of-type {
     bottom: 0px;
+    display: none;
 }
 
 nav.menu button:hover {


### PR DESCRIPTION
## Description

reduce the height of side menu in the help section. allow scrolling to the bottom in the y axis

## Why

the menu of the help application exceeds the browser window and the user can not see the full content.

## Issue

NA

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally