### PR TITLE
bugfix(side menu): remove double scroll in side menu section

### DIFF
--- a/public/documentation/css/Chapter.css
+++ b/public/documentation/css/Chapter.css
@@ -42,7 +42,7 @@ nav.menu {
     flex-direction: row;
     transition: width 0.1s;
     height: 75vh;
-    overflow-y: scroll;
+    overflow-y: hidden;
 }
 
 nav.menu.open {
@@ -50,7 +50,7 @@ nav.menu.open {
 }
 
 nav.menu.open ul.level1 {
-    max-height: calc(100vh - 10px);
+    max-height: 67vh;
 }
 
 nav.menu.open .home {
@@ -62,7 +62,7 @@ nav.menu.open .scroller {
     width: 100%;
     margin-top: 76px;
     position: relative;
-    height: 100%;
+    height: 89%;
 }
 
 nav.menu.closed,
@@ -97,7 +97,6 @@ nav.menu button.scroll:first-of-type {
 
 nav.menu button.scroll:last-of-type {
     bottom: 0px;
-    display: none;
 }
 
 nav.menu button:hover {

--- a/public/documentation/js/Main.js
+++ b/public/documentation/js/Main.js
@@ -337,7 +337,7 @@ class Navigation extends Viewable {
 
     createScrollTopButton() {
         return addEvents(
-            N('button', '⏶', { class: 'scroll' }),
+            N('button', '↑', { class: 'scroll' }),
             {
                 click: (() => {
                     this.menu.scrollTo({ top: 0, behavior: 'smooth' })
@@ -348,7 +348,7 @@ class Navigation extends Viewable {
 
     createScrollBottomButton() {
         return addEvents(
-            N('button', '⏷', { class: 'scroll' }),
+            N('button', '↓', { class: 'scroll' }),
             {
                 click: (() => {
                     this.menu.scrollTo({ top: this.menu.scrollHeight, behavior: 'smooth' })


### PR DESCRIPTION
## Description

fix double scroll in side menu. show arrows at the top and bottom of the side menu

## Why

side menu shows double scroll

## Issue

NA

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally