### PR TITLE
chore: attribute logos in notice

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -34,11 +34,27 @@ The project maintains the following source code repositories in the GitHub organ
 
 This project leverages the following third party content:
 
+See DEPENDENCIES file.
+
+This project uses the following font:
+
 * License: Open Font License 1.1
 * Licence Path: https://github.com/impallari/Libre-Franklin/blob/master/OFL.txt
 * Source URL: https://github.com/impallari/Libre-Franklin
 
-See DEPENDENCIES file.
+This project uses the following image content:
+
+* Image: Catena-X Logo
+* Source URL: https://catena-x.net
+
+* Image: German Edge Cloud Logo
+* Source URL: https://gec.io
+
+* Image: SAP Logo
+* Source URL: https://www.sap.com
+
+* Image: Siemens-X Logo
+* Source URL: https://www.siemens.com
 
 ## Cryptography
 

--- a/public/assets/images/content/CX.jpg.license
+++ b/public/assets/images/content/CX.jpg.license
@@ -1,6 +1,0 @@
-This work is licensed under the [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode).
-
-- SPDX-License-Identifier: CC-BY-4.0
-- SPDX-FileCopyrightText: Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
-- Source URL: https://github.com/eclipse-tractusx/portal-assets
-

--- a/public/assets/images/content/GEC.jpg.license
+++ b/public/assets/images/content/GEC.jpg.license
@@ -1,6 +1,0 @@
-This work is licensed under the [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode).
-
-- SPDX-License-Identifier: CC-BY-4.0
-- SPDX-FileCopyrightText: Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
-- Source URL: https://github.com/eclipse-tractusx/portal-assets
-

--- a/public/assets/images/content/SAP.jpg.license
+++ b/public/assets/images/content/SAP.jpg.license
@@ -1,6 +1,0 @@
-This work is licensed under the [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode).
-
-- SPDX-License-Identifier: CC-BY-4.0
-- SPDX-FileCopyrightText: Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
-- Source URL: https://github.com/eclipse-tractusx/portal-assets
-

--- a/public/assets/images/content/Siemens.jpg.license
+++ b/public/assets/images/content/Siemens.jpg.license
@@ -1,6 +1,0 @@
-This work is licensed under the [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode).
-
-- SPDX-License-Identifier: CC-BY-4.0
-- SPDX-FileCopyrightText: Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
-- Source URL: https://github.com/eclipse-tractusx/portal-assets
-


### PR DESCRIPTION
## Description

attribute logos in notice

## Why

[third-party-content](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-07#third-party-content)

## Issue

n/a

## Checklist

- [x] I have performed a self-review of my own code
