### PR TITLE
feature/technical user credential reset

### DIFF
--- a/developer/03. User Management/03. Technical User/04. Reset Credentials.md
+++ b/developer/03. User Management/03. Technical User/04. Reset Credentials.md
@@ -1,0 +1,31 @@
+## Introduction
+
+The technical user owned or managed by an company can get self-managed in regards of the credential reset.
+This might be relevant if the credentials are getting old/long used already, due to company security regulations or/and in the case of a credential loss/unwanted publication.
+
+<br>
+
+Functional Description: [Click here](/docs/03.%20User%20Management/03.%20Technical%20User/04.%20Reset%20Credentials.md)
+
+<br>
+
+### Reset Credential
+
+With a click on the button "Credential Reset" the API Endpoint (see below) is getting triggered. The API response includes (in case of a successful reset) the new credential and will get immediately displayed to the user via the screen.
+
+<br>
+
+```diff
+! PUT /api/administration/serviceaccount/owncompany/serviceaccounts/{serviceAccountId}/resetCredentials
+```
+
+<br>
+
+Request body
+
+		n/a
+		managed via endpoint path
+
+
+<br>
+<br>

--- a/docs/03. User Management/03. Technical User/04. Reset Credentials.md
+++ b/docs/03. User Management/03. Technical User/04. Reset Credentials.md
@@ -1,0 +1,29 @@
+## Introduction
+
+The technical user owned or managed by an company can get self-managed in regards of the credential reset.
+This might be relevant if the credentials are getting old/long used already, due to company security regulations or/and in the case of a credential loss/unwanted publication.
+
+<br>
+
+### Reset Credential
+
+To reset a credential of an specific technical user, the user must open the User Management -> Technical User Management -> Open up the technical user details
+
+<p>
+<img width="800" alt="image" src="https://github.com/catenax-ng/tx-portal-assets/assets/94133633/76e48963-eda7-4a77-bdc4-6ff683764fa9">
+</p>
+
+<br>
+<br>
+
+Inside the technical user detail screen - the button "Reset Credential" is available.
+By clicking on the "Reset" button, the credential will get updated and automatically displayed inside the technical user detail table below - under "Secret".
+
+<br>
+
+<p>
+<img width="835" alt="image" src="https://github.com/catenax-ng/tx-portal-assets/assets/94133633/61d66a6f-3da1-4faa-8741-f2034a41f7bc">
+</p>
+
+<br>
+<br>


### PR DESCRIPTION
## Description

Refresh technical user credential

## Why

New feature to enable company users to refresh the secret of owned/managed technical users

## Issue

n/a

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
