### PR TITLE
Enhance/vc document upload file validation

### DIFF
--- a/docs/06. Certificates/01. UseCase Participation.md
+++ b/docs/06. Certificates/01. UseCase Participation.md
@@ -26,12 +26,18 @@ The submission will trigger a request on the operator side and needs to get appr
 <br>
 <br>
 
-To view the current state of the credential request, the status can get viewed
+> **_NOTE:_**  Only PDF files upto 2 MB are allowed to get loaded.
+>
+> 
+
+<br>
+<br>
+
+To view the current state of the credential request, the status is getting displayed on the main page
 
 <img width="96" alt="image" src="https://github.com/catenax-ng/tx-portal-assets/assets/94133633/fd2401f1-1295-4e11-a32c-3401094d480a">
 <br>
 <img width="77" alt="image" src="https://github.com/catenax-ng/tx-portal-assets/assets/94133633/bb3f3985-d2d7-4aeb-a4b0-1c4a2303333f">
-
 
 <br>
 <br>

--- a/docs/06. Certificates/02. Other Certificates.md
+++ b/docs/06. Certificates/02. Other Certificates.md
@@ -30,6 +30,11 @@ The overlay for the certificate upload is displayed and the user can upload the 
 <br>
 <br>
 
+> **_NOTE:_**  Only PDF files upto 2 MB are allowed to get uploaded.
+
+<br>
+<br>
+
 The submission will trigger a request on the operator side and needs to get approved by the same before the credential is successfully added inside the company wallet.
 
 <br>

--- a/docs/06. Certificates/02. Other Certificates.md
+++ b/docs/06. Certificates/02. Other Certificates.md
@@ -10,7 +10,7 @@ Currently Supported:
 
 Accessing the company certificate credentials requestpage can be done via the user navigation
 
->br>
+<br>
 <img width="152" alt="image" src="https://github.com/catenax-ng/tx-portal-assets/assets/94133633/a3f216e7-e499-47e3-892e-c7971000408a">
 <br>
 <br>


### PR DESCRIPTION
## Description

Add VC Request file upload validation information

## Why

The dropzone got enhanced to only allow pdf files with an size upto 2MB

## Issue

n/a

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
