### PR TITLE
build(arch): provide image also for arm64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,6 +55,9 @@ jobs:
       - name: Build Application
         run: yarn build
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
       - name: Login to DockerHub
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v2
@@ -76,6 +79,7 @@ jobs:
         with:
           context: .
           file: .conf/Dockerfile
+          platforms: linux/amd64, linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Description

build images also for arm64, in addition to amd64

## Why

enable localdev umbrella chart: arm64 images needed for usage on Mac

## Issue

[localdev](https://github.com/eclipse-tractusx/portal-cd/pull/90)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
