### PR TITLE
build(trg-7.05): add legal info at build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
 **/.DS_Store
 node_modules
 public/documentation/js/lib
+
+# Add legal info files during build
+
+public/assets/notice/LICENSE
+public/assets/notice/DEPENDENCIES
+public/assets/notice/NOTICE.md
+public/assets/notice/SECURITY.md

--- a/package.json
+++ b/package.json
@@ -23,8 +23,9 @@
   },
   "scripts": {
     "build:release": "node src/documentation/Release.js ${1}",
-    "build": "./scripts/build.sh",
+    "build": "yarn build:copy-legal-info && ./scripts/build.sh",
     "build:legal-notice": "bash scripts/legal-notice.sh",
+    "build:copy-legal-info": "cp LICENSE NOTICE.md DEPENDENCIES SECURITY.md public/assets/notice/",
     "build:sources": "zip -r portal-assets.zip src package.json yarn.lock -x '*.stories.*' -x '*.test.*' -x '*.ttf' -x '*.svg' -x '*.png' -x '*.jpg'",
     "start": "concurrently \"yarn start:assets\" \"yarn start:proxy\" \"open http://localhost:3000/\"",
     "start:proxy": "node src/proxy/index.cjs",


### PR DESCRIPTION
## Description

add legal info (LICENSE NOTICE.md DEPENDENCIES SECURITY.md) at build

## Why

https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-05

## Issue

https://github.com/eclipse-tractusx/portal-assets/issues/207

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
