### PR TITLE
chore: adjust technical user role documentation

### DIFF
--- a/developer/Technical Documentation/Version Upgrade/portal-upgrade-details.md
+++ b/developer/Technical Documentation/Version Upgrade/portal-upgrade-details.md
@@ -106,7 +106,7 @@ NEW portal.onboarding_service_provider_details to safe information of the onboar
 
 #### Technical Role - UPDATE
 
-To align the portal database with the Keycloak database the following SQL must be executed against the portal database. The script will replace the 'Connector User' role with the roles 'Semantic Model Management' and 'Dataspace Discovery'. As well as replace the 'App Tech User' role with 'Semantic Model Management', 'Dataspace Discovery' and 'CX Membership Info'. This results in all identity assigned roles being replaced, all technical user profile assigned roles being updated and the old roles being removed from the database.
+To align the portal database with the Keycloak database the following SQL must be executed against the portal database. The script will replace the 'Connector User' role with the roles 'Semantic Model Management', 'Identity Wallet Management' and 'Dataspace Discovery'. As well as replace the 'App Tech User' role with 'Semantic Model Management', 'Dataspace Discovery' and 'CX Membership Info'. This results in all identity assigned roles being replaced, all technical user profile assigned roles being updated and the old roles being removed from the database.
 
 ```sql
 WITH connector_users AS (
@@ -145,7 +145,7 @@ roles_to_insert AS (
     CROSS JOIN (
         SELECT id
         FROM portal.user_roles
-        WHERE user_role IN ('Semantic Model Management', 'Identity Wallet Management', 'Dataspace Discovery', 'CX Membership Info')
+        WHERE user_role IN ('Semantic Model Management', 'Dataspace Discovery', 'CX Membership Info')
     ) ur
 )
 INSERT INTO portal.identity_assigned_roles (identity_id, user_role_id)
@@ -191,7 +191,7 @@ profiles_to_insert AS (
     CROSS JOIN (
         SELECT id
         FROM portal.user_roles
-        WHERE user_role IN ('Semantic Model Management', 'Identity Wallet Management','Dataspace Discovery', 'CX Membership Info')
+        WHERE user_role IN ('Semantic Model Management', 'Dataspace Discovery', 'CX Membership Info')
     ) ur
 )
 INSERT INTO portal.technical_user_profile_assigned_user_roles (technical_user_profile_id, user_role_id)

--- a/developer/Technical Documentation/Version Upgrade/portal-upgrade-details.md
+++ b/developer/Technical Documentation/Version Upgrade/portal-upgrade-details.md
@@ -17,6 +17,7 @@
   - [v1.1.0](#v110)
     - [Application Checklist - ENHANCED](#application-checklist---enhanced)
     - [Service Details - NEW (interim)](#service-details---new-interim)
+- [NOTICE](#notice)
 
 ## Summary
 
@@ -121,7 +122,7 @@ connector_roles_to_insert AS (
     CROSS JOIN (
         SELECT id
         FROM portal.user_roles
-        WHERE user_role IN ('Semantic Model Management', 'Dataspace Discovery')
+        WHERE user_role IN ('Semantic Model Management', 'Identity Wallet Management', 'Dataspace Discovery')
     ) AS ur
 )
 INSERT INTO portal.identity_assigned_roles (identity_id, user_role_id)
@@ -144,7 +145,7 @@ roles_to_insert AS (
     CROSS JOIN (
         SELECT id
         FROM portal.user_roles
-        WHERE user_role IN ('Semantic Model Management', 'Dataspace Discovery', 'CX Membership Info')
+        WHERE user_role IN ('Semantic Model Management', 'Identity Wallet Management', 'Dataspace Discovery', 'CX Membership Info')
     ) ur
 )
 INSERT INTO portal.identity_assigned_roles (identity_id, user_role_id)
@@ -167,7 +168,7 @@ connector_profiles_to_insert AS (
     CROSS JOIN (
         SELECT id
         FROM portal.user_roles
-        WHERE user_role IN ('Semantic Model Management', 'Dataspace Discovery')
+        WHERE user_role IN ('Semantic Model Management', 'Identity Wallet Management', 'Dataspace Discovery')
     ) ur
 )
 INSERT INTO portal.technical_user_profile_assigned_user_roles (technical_user_profile_id, user_role_id)
@@ -190,7 +191,7 @@ profiles_to_insert AS (
     CROSS JOIN (
         SELECT id
         FROM portal.user_roles
-        WHERE user_role IN ('Semantic Model Management', 'Dataspace Discovery', 'CX Membership Info')
+        WHERE user_role IN ('Semantic Model Management', 'Identity Wallet Management','Dataspace Discovery', 'CX Membership Info')
     ) ur
 )
 INSERT INTO portal.technical_user_profile_assigned_user_roles (technical_user_profile_id, user_role_id)


### PR DESCRIPTION
Description

Adjusted the upgrade script for the keycloak roles

Why

Currently the role assignment is missing one role, this is added with this pr

Issue

N/A

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have added copyright and license headers, footers (for .md files) or files (for images)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
