### PR TITLE
fix(docs-app): remove static folder

### DIFF
--- a/src/documentation/Release.js
+++ b/src/documentation/Release.js
@@ -20,6 +20,8 @@
 import fs from 'fs'
 import dirTree from 'directory-tree'
 
+const exclude = /\/static(\/|$)/
+
 class MDHelper {
   readContent(path) {
     if (!fs.lstatSync(path).isFile()) return ''
@@ -39,15 +41,16 @@ class MDHelper {
   extractChapterTree(tree) {
     if (fs.lstatSync(tree.path).isFile())
       tree.chapter = this.parseChapters(tree.path)
-    else if (tree.children)
+    else if (tree.children) {
       tree.children.forEach((child) => this.extractChapterTree(child))
+    }
     return tree
   }
 }
 
 class TreeHelper {
   static readDirTree(root) {
-    const tree = dirTree(root)
+    const tree = dirTree(root, { exclude })
     //const tree = Transformer.tree2map({}, dirTree(root), undefined, 0, 0)
     return tree
   }


### PR DESCRIPTION
## Description

Remove static content folder from table of contents.

## Why

The static contents folder showed up in the list of chapters.

## Issue

n/a

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally