### PR TITLE
fix(docs-apps): repair missing images

### DIFF
--- a/developer/Technical Documentation/Interface Contracts/BPDM.md
+++ b/developer/Technical Documentation/Interface Contracts/BPDM.md
@@ -15,7 +15,7 @@ Business Partner Data Management as a product as well as the portal have three d
 Below the respective touched business process steps are highlighted to enable an easier mapping of the interfaces to the portal product business process:
 
 <p align="center">
-<img width="843" alt="image" src="/docs/static/bpdm-touchpoints.png">
+<img width="843" alt="image" src="https://raw.githubusercontent.com/eclipse-tractusx/portal-assets/main/docs/static/bpdm-touchpoints.png">
 </p>
 
 <br>
@@ -47,7 +47,7 @@ For the registration process we are using the BPDM data call to pull the company
 To integrate the API into CX onboarding process, portal team just have to call the lookup REST endpoint and transform the response into a pick list for the portal user.
 <br>
 <br>
-<img width="904" alt="image" src="/docs/static/bpdm-golden-record-overview.png">
+<img width="904" alt="image" src="https://raw.githubusercontent.com/eclipse-tractusx/portal-assets/main/docs/static/bpdm-golden-record-overview.png">
 <br>
 <br>
 
@@ -60,7 +60,7 @@ Retrieving company data from the CX mirror.
 ### Description of the physical interfaces (HOW)
 
 <br>
-<img width="1200" alt="image" src="/docs/static/bpdm-physical-interfaces.png">
+<img width="1200" alt="image" src="https://raw.githubusercontent.com/eclipse-tractusx/portal-assets/main/docs/static/bpdm-physical-interfaces.png">
 <br>
 <br>
 
@@ -131,7 +131,7 @@ The Golden Record has a couple of implemented validations to validate the regist
 <br>
 
 <p align="center">
-<img width="821" alt="image" src="/docs/static/bpdm-process-worker.png">
+<img width="821" alt="image" src="https://raw.githubusercontent.com/eclipse-tractusx/portal-assets/main/docs/static/bpdm-process-worker.png">
 </p>
 
 <br>
@@ -206,7 +206,7 @@ The interface is used to fetch the BPN of the previously submitted party registr
 ### Architecture Overview
 
 <p align="center">
-<img width="803" alt="image" src="/docs/static/bpdm-process-worker-pull.png">
+<img width="803" alt="image" src="https://raw.githubusercontent.com/eclipse-tractusx/portal-assets/main/docs/static/bpdm-process-worker-pull.png">
 </p>
 
 <br>
@@ -278,7 +278,7 @@ This document describes the details of the interface spec between BPDM and Porta
 ### Architecture Overview
 
 <p align="center">
-<img width="780" alt="image" src="/docs/static/bpdm-partner-network.png">
+<img width="780" alt="image" src="https://raw.githubusercontent.com/eclipse-tractusx/portal-assets/main/docs/static/bpdm-partner-network.png">
 </p>
 
 <br>

--- a/developer/Technical Documentation/Version Upgrade/portal-upgrade-details.md
+++ b/developer/Technical Documentation/Version Upgrade/portal-upgrade-details.md
@@ -45,7 +45,7 @@ values ('68d28f88-85fc-43a9-835a-fce0d5a9e665', 300, 1, '2023-02-21 08:15:20.479
 
 The `identity_providers` table has been adjusted to provide the possibility to safe the owner of the idp.
 
-![IdentityProvidersUpdate](/docs/static/IdentityProvidersUpdate.png)
+![IdentityProvidersUpdate](https://raw.githubusercontent.com/eclipse-tractusx/portal-assets/main/docs/static/IdentityProvidersUpdate.png)
 
 - added "Identity_Provider_Types" table which is connected to portal.identity_providers table
 - added inside the new table "Identity_Provider_Types" an id as well as a label. Labels are defined below:
@@ -89,7 +89,7 @@ Logic:
 
 The `company_applications` table has been expanded. New columns `company_application_type`, `onboarding_service_provider_id` have been added to have the possibility to track which onboarding service provider started an application for a specific company.
 
-![CompanyApplicationTypes](/docs/static/CompanyApplicationTypes.png)
+![CompanyApplicationTypes](https://raw.githubusercontent.com/eclipse-tractusx/portal-assets/main/docs/static/CompanyApplicationTypes.png)
 
 "onboarding_service_provider_id" => nullable
 "external" => enum; 1 = "INTERNAL", 2 = "EXTERNAL"
@@ -384,11 +384,11 @@ New verified_credential_external_types, verified_credential_external_type_use_ca
 
 Company SSI Database Structure
 
-![company-ssi-database](/docs/static/company-ssi-database.png)
+![company-ssi-database](https://raw.githubusercontent.com/eclipse-tractusx/portal-assets/main/docs/static/company-ssi-database.png)
 
 Use Case Database Structure
 
-![use-case-database](/docs/static/use-case-database.png)
+![use-case-database](https://raw.githubusercontent.com/eclipse-tractusx/portal-assets/main/docs/static/use-case-database.png)
 
 - NEW: table "language_long_names"
 - ENHANCED: table portal.languages "long_name_de" and "long_name_en" removed
@@ -525,7 +525,7 @@ Attributes
 - service_type_id (connected to portal.service_types and replacing table service_assigned_service_types)
 - technical_user_needed (true/false flag)
 
-![ServiceDetails](/docs/static/ServiceDetails.png)
+![ServiceDetails](https://raw.githubusercontent.com/eclipse-tractusx/portal-assets/main/docs/static/ServiceDetails.png)
 
 Impact on existing data:
 Migration script existing, based on the service type which is fetched for all existing data from portal table service_assigned_service_types, the technical_user_needed attribute is set to "true" for "DATASPACE_SERVICE" services and "false" for "CONSULTANCE_SERVICE".

--- a/docs/03. User Management/01. User Account/04. Create new user account (bulk).md
+++ b/docs/03. User Management/01. User Account/04. Create new user account (bulk).md
@@ -5,7 +5,7 @@ Please note that it is suggested to separate the bulk user create groups per rol
 
 <br>
 
-<img width="580" alt="image" src="/docs/static/create-user-bulk.png">
+<img width="580" alt="image" src="https://raw.githubusercontent.com/eclipse-tractusx/portal-assets/main/docs/static/create-user-bulk.png">
 
 <br>
 <br>
@@ -56,7 +56,7 @@ Note: if a user inside the csv file upload fails in the user account creation, t
 
 <br>
 
-<img width="593" alt="image" src="/docs/static/create-user-bulk-feedback.png">
+<img width="593" alt="image" src="https://raw.githubusercontent.com/eclipse-tractusx/portal-assets/main/docs/static/create-user-bulk-feedback.png">
 
 <br>
 <br>

--- a/docs/04. App(s)/02. App Release Process/index.md
+++ b/docs/04. App(s)/02. App Release Process/index.md
@@ -31,7 +31,7 @@ Access the "App Overview" page via the top navigation "App Management"
 <br>
 <br>
 
-<img width="222" alt="image" src="/docs/static/register-app.png">
+<img width="222" alt="image" src="https://raw.githubusercontent.com/eclipse-tractusx/portal-assets/main/docs/static/register-app.png">
 
 <br>
 <br>
@@ -43,7 +43,7 @@ and click on
 <br>
 <br>
 
-<img width="187" alt="image" src="/docs/static/register-app-button.png">
+<img width="187" alt="image" src="https://raw.githubusercontent.com/eclipse-tractusx/portal-assets/main/docs/static/register-app-button.png">
 
 <br>
 <br>

--- a/docs/04. App(s)/06. App Change Process/07. Document Change.md
+++ b/docs/04. App(s)/06. App Change Process/07. Document Change.md
@@ -2,7 +2,7 @@
 
 <br>
 
-<img width="636" alt="image" src="/docs/static/update-contract-documents.png">
+<img width="636" alt="image" src="https://raw.githubusercontent.com/eclipse-tractusx/portal-assets/main/docs/static/update-contract-documents.png">
 
 <br>
 

--- a/docs/09. Others/12. Offer Authentication Flow.md
+++ b/docs/09. Others/12. Offer Authentication Flow.md
@@ -31,7 +31,7 @@ The integration to the operator Keycloak enables:
 
 ## Highlevel Process
 
-<img width="756" alt="image" src="/docs/static/high-level-app-process.png">
+<img width="756" alt="image" src="https://raw.githubusercontent.com/eclipse-tractusx/portal-assets/main/docs/static/high-level-app-process.png">
 
 <br>
 <br>


### PR DESCRIPTION
## Description

Repair broken images in docs-app due to relative links.

## Why

Some images had a relative URL and were displayed in GitHub but not in the documentation app.
The docs app needs to be enabled for relative links.

## Issue

ref: Jira CPLP-3561

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally