### PR TITLE
fix(company roles): standard library title and description

### DIFF
--- a/public/assets/content/de/companyroles.json
+++ b/public/assets/content/de/companyroles.json
@@ -245,8 +245,8 @@
         ]
       },
       {
-        "title": "Standard Libraries",
-        "description": "",
+        "title": "App Provider Certification Standards",
+        "description": "The Catena-X operating environment is based on the idea that there are multiple but distinct roles that aim at providing an attractive and fully functional ecosystem. Each provider can take on one or more of the following roles in any combination:<1></1><1></1>1. Core Service Provider<1></1><1></1>2. Enablement Service Provider<1></1><1></1>3. Business Application Provider<1></1><1></1>4. On-Boarding Service Provider<1></1><1></1>5. Consulting Provider<1></1><1></1>6. Data Provider and Consumer<1></1><1></1>7. Conformity Assessment Body<1></1><1></1>In the list you can find all current active standards relevant for App Provider Certification certification.",
         "imagePath": "",
         "backgroundColor": "#FFFFFF",
         "id": "std-libraries-id",
@@ -420,8 +420,8 @@
         ]
       },
       {
-        "title": "Standard Libraries",
-        "description": "",
+        "title": "Service Provider Certification Standards",
+        "description": "The Catena-X operating environment is based on the idea that there are multiple but distinct roles that aim at providing an attractive and fully functional ecosystem. Each provider can take on one or more of the following roles in any combination:<1></1><1></1>1. Core Service Provider<1></1><1></1>2. Enablement Service Provider<1></1><1></1>3. Business Application Provider<1></1><1></1>4. On-Boarding Service Provider<1></1><1></1>5. Consulting Provider<1></1><1></1>6. Data Provider and Consumer<1></1><1></1>7. Conformity Assessment Body<1></1><1></1>In the list you can find all current active standards relevant for Service Provider Certification certification.",
         "imagePath": "",
         "backgroundColor": "#FFFFFF",
         "id": "std-libraries-id",
@@ -706,8 +706,8 @@
         ]
       },
       {
-        "title": "Standard Libraries",
-        "description": "",
+        "title": "Participant Certification Standards",
+        "description": "The Catena-X operating environment is based on the idea that there are multiple but distinct roles that aim at providing an attractive and fully functional ecosystem. Each provider can take on one or more of the following roles in any combination:<1></1><1></1>1. Core Service Provider<1></1><1></1>2. Enablement Service Provider<1></1><1></1>3. Business Application Provider<1></1><1></1>4. On-Boarding Service Provider<1></1><1></1>5. Consulting Provider<1></1><1></1>6. Data Provider and Consumer<1></1><1></1>7. Conformity Assessment Body<1></1><1></1>In the list you can find all current active standards relevant for Participant Certification certification.",
         "imagePath": "",
         "backgroundColor": "#FFFFFF",
         "id": "std-libraries-id",
@@ -765,8 +765,8 @@
         }
       },
       {
-        "title": "Standard Libraries",
-        "description": "",
+        "title": "Conformity Assessment Bodies Certification Standards",
+        "description": "The Catena-X operating environment is based on the idea that there are multiple but distinct roles that aim at providing an attractive and fully functional ecosystem. Each provider can take on one or more of the following roles in any combination:<1></1><1></1>1. Core Service Provider<1></1><1></1>2. Enablement Service Provider<1></1><1></1>3. Business Application Provider<1></1><1></1>4. On-Boarding Service Provider<1></1><1></1>5. Consulting Provider<1></1><1></1>6. Data Provider and Consumer<1></1><1></1>7. Conformity Assessment Body<1></1><1></1>In the list you can find all current active standards relevant for Conformity Assessment Bodies certification.",
         "imagePath": "",
         "backgroundColor": "#FFFFFF",
         "id": "std-libraries-id",
@@ -793,11 +793,6 @@
       },
       {
         "index": 4,
-        "title": "standard libraries",
-        "navigation": "std-libraries-id"
-      },
-      {
-        "index": 5,
         "title": "standard libraries",
         "navigation": "std-libraries-id"
       }
@@ -888,8 +883,8 @@
         "template": "TextImageSideBySideWithSections"
       },
       {
-        "title": "Standard Libraries",
-        "description": "",
+        "title": "Onboarding Service Provider Certification Standards",
+        "description": "The Catena-X operating environment is based on the idea that there are multiple but distinct roles that aim at providing an attractive and fully functional ecosystem. Each provider can take on one or more of the following roles in any combination:<1></1><1></1>1. Core Service Provider<1></1><1></1>2. Enablement Service Provider<1></1><1></1>3. Business Application Provider<1></1><1></1>4. On-Boarding Service Provider<1></1><1></1>5. Consulting Provider<1></1><1></1>6. Data Provider and Consumer<1></1><1></1>7. Conformity Assessment Body<1></1><1></1>In the list you can find all current active standards relevant for Onboarding Service Provider certification.",
         "imagePath": "",
         "backgroundColor": "#FFFFFF",
         "id": "std-libraries-id",

--- a/public/assets/content/de/dataspace.json
+++ b/public/assets/content/de/dataspace.json
@@ -40,7 +40,7 @@
         "description": "Mithilfe von Richtlinien werden Datenzugriffsrichtlinien sowie Nutzungsdetails definiert.<1></1><1></1>'Access' bedeutet, dass festgelegt wird, wer Datenangebote sehen kann. Die Nutzung definiert den Datenzugriff selbst – also Vertragsverhandlungen und Datenverbrauch. Z.B. Unternehmen A kann sehen, dass Unternehmen B ein Datenangebot für die in der letzten Woche produzierten Fahrzeugdaten hat. Aufgrund fehlender Nutzungsrechte kann das Unternehmen die Vereinbarung/das Datenangebot jedoch nicht annehmen und hat keinen Zugriff auf diese Daten.<1></1>< 1></1>Auf der folgenden Seite finden Sie Einzelheiten zu den jeweils verfügbaren Zugriffs-/Nutzungsrichtlinien<1></1><1></1>",
         "imagePath": "/images/frame/AccessVsUsage.png",
         "backgroundColor": "#FFFFFFF",
-        "id": "core-id",
+        "id": "intro-id",
         "template": "TextImageSideBySide",
         "sectionLink": {
           "data": [

--- a/public/assets/content/en/companyroles.json
+++ b/public/assets/content/en/companyroles.json
@@ -245,8 +245,8 @@
         ]
       },
       {
-        "title": "Standard Libraries",
-        "description": "",
+        "title": "App Provider Certification Standards",
+        "description": "The Catena-X operating environment is based on the idea that there are multiple but distinct roles that aim at providing an attractive and fully functional ecosystem. Each provider can take on one or more of the following roles in any combination:<1></1><1></1>1. Core Service Provider<1></1><1></1>2. Enablement Service Provider<1></1><1></1>3. Business Application Provider<1></1><1></1>4. On-Boarding Service Provider<1></1><1></1>5. Consulting Provider<1></1><1></1>6. Data Provider and Consumer<1></1><1></1>7. Conformity Assessment Body<1></1><1></1>In the list you can find all current active standards relevant for App Provider Certification certification.",
         "imagePath": "",
         "backgroundColor": "#FFFFFF",
         "id": "std-libraries-id",
@@ -420,8 +420,8 @@
         ]
       },
       {
-        "title": "Standard Libraries",
-        "description": "",
+        "title": "Service Provider Certification Standards",
+        "description": "The Catena-X operating environment is based on the idea that there are multiple but distinct roles that aim at providing an attractive and fully functional ecosystem. Each provider can take on one or more of the following roles in any combination:<1></1><1></1>1. Core Service Provider<1></1><1></1>2. Enablement Service Provider<1></1><1></1>3. Business Application Provider<1></1><1></1>4. On-Boarding Service Provider<1></1><1></1>5. Consulting Provider<1></1><1></1>6. Data Provider and Consumer<1></1><1></1>7. Conformity Assessment Body<1></1><1></1>In the list you can find all current active standards relevant for Service Provider Certification certification.",
         "imagePath": "",
         "backgroundColor": "#FFFFFF",
         "id": "std-libraries-id",
@@ -706,8 +706,8 @@
         ]
       },
       {
-        "title": "Standard Libraries",
-        "description": "",
+        "title": "Participant Certification Standards",
+        "description": "The Catena-X operating environment is based on the idea that there are multiple but distinct roles that aim at providing an attractive and fully functional ecosystem. Each provider can take on one or more of the following roles in any combination:<1></1><1></1>1. Core Service Provider<1></1><1></1>2. Enablement Service Provider<1></1><1></1>3. Business Application Provider<1></1><1></1>4. On-Boarding Service Provider<1></1><1></1>5. Consulting Provider<1></1><1></1>6. Data Provider and Consumer<1></1><1></1>7. Conformity Assessment Body<1></1><1></1>In the list you can find all current active standards relevant for Participant Certification certification.",
         "imagePath": "",
         "backgroundColor": "#FFFFFF",
         "id": "std-libraries-id",
@@ -765,8 +765,8 @@
         }
       },
       {
-        "title": "Standard Libraries",
-        "description": "",
+        "title": "Conformity Assessment Bodies Certification Standards",
+        "description": "The Catena-X operating environment is based on the idea that there are multiple but distinct roles that aim at providing an attractive and fully functional ecosystem. Each provider can take on one or more of the following roles in any combination:<1></1><1></1>1. Core Service Provider<1></1><1></1>2. Enablement Service Provider<1></1><1></1>3. Business Application Provider<1></1><1></1>4. On-Boarding Service Provider<1></1><1></1>5. Consulting Provider<1></1><1></1>6. Data Provider and Consumer<1></1><1></1>7. Conformity Assessment Body<1></1><1></1>In the list you can find all current active standards relevant for Conformity Assessment Bodies certification.",
         "imagePath": "",
         "backgroundColor": "#FFFFFF",
         "id": "std-libraries-id",
@@ -883,8 +883,8 @@
         "template": "TextImageSideBySideWithSections"
       },
       {
-        "title": "Standard Libraries",
-        "description": "",
+        "title": "Onboarding Service Provider Certification Standards",
+        "description": "The Catena-X operating environment is based on the idea that there are multiple but distinct roles that aim at providing an attractive and fully functional ecosystem. Each provider can take on one or more of the following roles in any combination:<1></1><1></1>1. Core Service Provider<1></1><1></1>2. Enablement Service Provider<1></1><1></1>3. Business Application Provider<1></1><1></1>4. On-Boarding Service Provider<1></1><1></1>5. Consulting Provider<1></1><1></1>6. Data Provider and Consumer<1></1><1></1>7. Conformity Assessment Body<1></1><1></1>In the list you can find all current active standards relevant for Onboarding Service Provider certification.",
         "imagePath": "",
         "backgroundColor": "#FFFFFF",
         "id": "std-libraries-id",

--- a/public/assets/content/en/dataspace.json
+++ b/public/assets/content/en/dataspace.json
@@ -40,7 +40,7 @@
         "description": "Policies are used to define data access policies as well as usage details.<1></1><1></1>Access means it defined who can view data offers. Usage defines the data access itself - means contract negotiations and data consumption. E.g. Company A can see that Company B has a Data Offer of last week produced vehicle data - however due to missing usage rights the company can not accept the agreement/data offer and can't access those data.<1></1><1></1>The following page provides details about the respective available access/usage policies<1></1><1></1>",
         "imagePath": "/images/frame/AccessVsUsage.png",
         "backgroundColor": "#FFFFFFF",
-        "id": "core-id",
+        "id": "intro-id",
         "template": "TextImageSideBySide",
         "sectionLink": {
           "data": [


### PR DESCRIPTION
## Description

add title and description to the standard library section based on the company role

## Why

all company roles section displays same content

## Issue

NA

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [ ] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [ ] I have created and linked IP issues or requested their creation by a committer
- [ ] I have added copyright and license headers, footers (for .md files) or files (for images)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [ ] I have added tests that prove my changes work
- [ ] I have checked that new and existing tests pass locally with my changes
- [ ] I have commented my code, particularly in hard-to-understand areas
