### PR TITLE
docs: add autosetup details

### DIFF
--- a/docs/developer/Technical Documentation/Interface Contracts/Offer-Autosetup.md
+++ b/docs/developer/Technical Documentation/Interface Contracts/Offer-Autosetup.md
@@ -1,17 +1,13 @@
 # Offer Autosetup
 
-## Interface / API / Service Summary
+The offer autosetup is used to
 
-For the case of a service setup / app, where an autosetup is available, CX will offer a standardized interface to push the relevant information to the service provider, which can trigger the service setup, if relevant.
-<br>
-Following interfaces are relevant to enable the autosetup
-
-1. POST Service URL (Generic endpoint for service providers to store their autosetup - if available - url inside CX)
-2. POST Service Request (Specific endpoint to trigger customer subscription)
-3. POST Instance Details (Register service instance for customer inside CX)
-
-<br>
-<br>
+- enable app/service provider to configure and activate the offer subscription triggered by an customer
+- the service offers two possibilities:
+  - either automate the full flow; or
+  - run it via any UI
+ 
+In the page below the functional details and technical implementation possibilities are explained.
 
 ## Architecture Overview
 
@@ -22,45 +18,40 @@ Following interfaces are relevant to enable the autosetup
 <br>
 <br>
 
-### #2 Details
+## Integration
+
+Every offer provider 8app as well as service) can integrate to the autosetup interface by executing following steps
+
+1. Configure your company internal service/app ramp-up service
+2. ...
+3. ...
 
 <br>
 <br>
 
-## Implementation
+### #1 Configure your company internal service/app ramp-up service
 
-### #1 PUT Service URL
+The portal provides via the UI as well as callable by technical users with the permission configuration of "Offer Management" the possibility to configure the offer company endpoint used to ramp-up the services/apps offered by the company.
 
-The PUT service url is enabling the service / app provider to store/hold the service partner / app partner autosetup url.
+**Path**: .../api/administration/serviceprovider/owncompany  
+**Method**: PUT  
+**Description**: Store the service partner/app partner autosetup url. The endpoint is only available for companies with the company role app provider/service provider. Company Role change process is defined under the following link [Change Company Role](/docs/user/02.%20Technical%20Integration/05.%20Company%20Role/Change%20Company%20Role.md)  
+With the first time calling the endpoint; the url will be set as app/service provider endpoint as a new data set.  
+With any further endpoint triggers; the existing record will get overwritten. Means; the app/service provider can have only one endpoint configured.  
+**Auth**: can get triggered by usern with the role App Manager; Service Manager and technical users with the role "Offer Management"
+
 <br>
-Logic: the service provider/app provider (must be an cx member) can trigger the endpoint to store the autosetup endpoint.
 <br>
 
+##### UI Flow Details:
 <img width="600" alt="image" src="https://raw.githubusercontent.com/eclipse-tractusx/portal-assets/main/docs/static/register-url-popup.png">
 
 <br>
-
-```diff
-! PUT api/administration/serviceprovider/owncompany
-```
-
-With the first time calling the endpoint; the url will be set as app/service provider endpoint as a new data set.  
-With any further endpoint triggers; the existing record will get overwritten. Means; the app/service provider can have only one endpoint configured.
-
-<br>
 <br>
 
-### #2 POST Service Request
 
-he service request (from the customer, to the provider) is getting stored and managed under this api.
-<br>
+After the endpoint is configured, all customer service/app subscription will trigger automatically the company configured endpoint with the following data:
 
-```diff
-! POST /api/services/{serviceId}/subscribe
-```
-
-<br>
-This API will be used to trigger (if available) the service provider endpoint (stored under #1) with the following body
 <br>
 
           [
@@ -88,11 +79,30 @@ This API will be used to trigger (if available) the service provider endpoint (s
 <br>
 <br>
 
-### #3 POST Service Instance
+### #2 The autosetup flow
 
-Post service request is used to create the customer service/app instance inside the portal db.  
-With the successful client/app instance creation on the portal side, the technical user for the AAS registry will get send within the response
-<br>
+After the customer request incl the customer data for service/app setup got provided to the offer provider, the offer provider is now supposed to
+
+- validate the request
+- ramp-up & configure the service/app
+- activate the subscription request of the customer
+
+For the *ramp-up and configuration* likely a technical user might be needed to (e.g. connect to a central provided service such as dataspace discovery, bpdm-pool, etc.). Since the offer provider did define the technical user needed profile in the app/service release process, the pre-saved configuration profile will be used now to create the technical user.
+The app/service provider is responsible to secure the technical user credentials carefully. The technical user is a critical element since this technical user is created on the behalf of the customer (means: the technical user claims are connected to the customer identity - this is mandatorily needed since the customer is the actual acting identity of the service/app - and not the app/service provider).
+
+The app/service provider is supposed to call the endpoint which triggers the automatic creation of all app/service instance relevant informations. Therefore 2 endpoints are available
+
+- POST /api/Apps/autoSetup (deprecated - still supported till 25.08.)
+- POST /api/Apps/start-autoSetup
+
+#### Details of POST /api/Apps/autoSetup
+
+**Path**: .../api/Apps/autoSetup  
+**Method**: POST  
+**Description**: Post service request is used to create the customer service/app instance inside the portal db.  
+With the successful client/app instance creation on the portal side, the technical user for the AAS registry will get send within the response.  
+**Auth**: can get triggered by usern with the role App Manager; Service Manager and technical users with the role "Offer Management"
+
 
 Request Body
 <br>
@@ -106,11 +116,8 @@ Request Body
 
 <br>
 
-```diff
-! POST: /api/services/autosetup
-```
 
-API Endpoint Logic
+##### API Endpoint Logic
 
 - Validate if requestId is existing in app_subscription table
 - Validate if user calling the endpoint is registered as service provider of the service/app
@@ -154,6 +161,7 @@ API Endpoint Logic
   - customer notification to inform the customer company about the activated app/service (receiver: customer app requester, customer IT admin)
 
 <br>
+<br>
 
 Response Body
 <br>
@@ -166,17 +174,60 @@ Response Body
 <br>
 <br>
 
+#### Details of POST /api/Apps/start-autoSetup
+
+As an functional extencion and more app/service provider centric approach, the endpoint /api/Apps/start-autoSetup got developed which is providing:
+- process worker used to setup offer provider relevant objects and user notifications
+- in case of system errors or process issues, data loss is prefented by using temp data storage and automatic retriggering of processes
+
+<br>
+
+**Path**: .../api/Apps/start-autoSetup  
+**Method**: POST  
+**Description**: ...
+**Auth**: can get triggered by usern with the role App Manager; Service Manager and technical users with the role "Offer Management"
+
+Request Body
+<br>
+
+          [
+           {
+             requestId (service request id),
+             appUrl (service provider endpoint / client / app)
+           }
+          ]
+
+<br>
+
+Compared to the deprecated endpoint mentioned above, the /start-autosetup is a asynchron endpoint working with process steps (as defined below)
+
+<br>
+
 ## Checklist Worker
 
-| Process Step                                         | Description                                                                                                                                                        | Success Scenario                                                                                                                 | Error (process_step status FAILED)         | Auto Retrigger?                                     | Manual Retrigger?                                                                       | Possible Following Steps                        |
-| ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------ | --------------------------------------------------- | --------------------------------------------------------------------------------------- | ----------------------------------------------- |
-| 100<br>Trigger Provider                              | Subscription Record creation in "PENDING" <br>Portal triggers the Offer Provider URL (if provider url is stored)                                                   | If the provider endpoint is responding with 20x <br>the process step will get set to "DONE" and "SKIPPED" if no URL is available | ??                                         | Yes, in case of an 5xx                              | Yes, in case of an 400 (wrong content) 404 (wrong url)                                  | Multi Instance: #101 <br> Single Instance: #103 |
-| 101<br>Start Autosetup                               | Provider is triggering the portal autosetup endpoint with necessary offer details<br>the step will trigger the portal internal autosetup jobs (102, 103, 104, 105) | The process step is set to "DONE" <br>with successful endpoint request body (which is getting stored in a temp table)            | -                                          | -                                                   | Step stays on "TO_DO" till the endpoint got successfully triggered (content is correct) | Apps: #102 <br>Services: #104                   |
-| 102<br>OfferSubscription Client Creation             | Created app client in Keycloak and DB, additionally app instance is getting created                                                                                | The process step is set to "DONE" <br>after all records are created                                                              | Status "FAILED" if job was running on fail | Yes, in case of an 5xx by keycloak                  | Yes, in case of an 4xx by keycloak                                                      | #104 <br>#105                                   |
-| 103<br>Single Instance Subscription Details Creation | Single Instance Subscription Details Creation                                                                                                                      | The process step is set to "DONE" <br>as soon as the url and instance is linked                                                  |                                            | -                                                   | -                                                                                       | #105                                            |
-| 104<br>Offr Subscription Technical User Creation     | Technical User creation in keycloak and metadata storage in portal db, additionally notification creation with technical client id                                 | The process step is set to "DONE" <br>after technical user ot successfully created                                               | Status "FAILED" if job was running on fail | Yes, in case of an 5xx by keycloak                  | Yes, in case of an 4xx by keycloak                                                      | #105                                            |
-| 105<br>Activate Subscription                         | Subscription record activation, notification creation and send email.                                                                                              | The process step is set to "DONE" <br>after xxx                                                                                  | xxx                                        | Yes, in case of an 5xx for the email - auto "TO_DO" | -                                                                                       | Multi Instance: #106 <br> Single Instance: -    |
-| 106<br>Trigger Provider Callback                     | Trigger provider callback url to share client and tech user.                                                                                                       | The process step is set to "DONE" <br>after xxx                                                                                  | xxx                                        | Yes, in case of an 5xx                              | Yes, in case of an 4xx                                                                  | -                                               |
+| Process Step                                         | Initiated by..                                         | Description                                                                                                                                                        | Success Scenario                                                                                                                 | Error (process_step status FAILED)         | Auto Retrigger?                                     | Manual Retrigger?                                                                       | Possible Following Steps                        |
+| ---------------------------------------------------- | ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------ | --------------------------------------------------- | --------------------------------------------------------------------------------------- | ----------------------------------------------- |
+| 100<br>Trigger Provider                              | Automatically by the portal application                              | Subscription Record creation in "PENDING" <br>Portal triggers the Offer Provider URL (if provider url is stored)                                                   | If the provider endpoint is responding with 20x <br>the process step will get set to "DONE" and "SKIPPED" if no URL is available | ??                                         | Yes, in case of an 5xx                              | Yes, in case of an 400 (wrong content) 404 (wrong url)                                  | Multi Instance: #101 <br> Single Instance: #103 |
+| 101<br>Start Autosetup                               | By the provider by running .../api/Apps/start-autoSetup                              | Provider is triggering the portal autosetup endpoint with necessary offer details<br>the step will trigger the portal internal autosetup jobs (102, 103, 104, 105) | The process step is set to "DONE" <br>with successful endpoint request body (which is getting stored in a temp table)            | -                                          | -                                                   | Step stays on "TO_DO" till the endpoint got successfully triggered (content is correct) | Apps: #102 <br>Services: #104                   |
+| 102<br>OfferSubscription Client Creation             | Automatically by the portal application             | Created app client in Keycloak and DB, additionally app instance is getting created                                                                                | The process step is set to "DONE" <br>after all records are created                                                              | Status "FAILED" if job was running on fail | Yes, in case of an 5xx by keycloak                  | Yes, in case of an 4xx by keycloak                                                      | #104 <br>#105                                   |
+| 103<br>Single Instance Subscription Details Creation | By the provider by running ?????                              | Single Instance Subscription Details Creation                                                                                                                      | The process step is set to "DONE" <br>as soon as the url and instance is linked                                                  |                                            | -                                                   | -                                                                                       | #105                                            |
+| 104<br>Offr Subscription Technical User Creation     | Automatically by the portal application             | Technical User creation in keycloak and metadata storage in portal db, additionally notification creation with technical client id                                 | The process step is set to "DONE" <br>after technical user ot successfully created                                               | Status "FAILED" if job was running on fail | Yes, in case of an 5xx by keycloak                  | Yes, in case of an 4xx by keycloak                                                      | #105                                            |
+| 105<br>Activate Subscription                         | By the provider by running .../api/Apps/subscription/{offerSubscriptionId}/activate-single-instance             | Subscription record activation, notification creation and send email.                                                                                              | The process step is set to "DONE" <br>after xxx                                                                                  | xxx                                        | Yes, in case of an 5xx for the email - auto "TO_DO" | -                                                                                       | Multi Instance: #106 <br> Single Instance: -    |
+| 106<br>Trigger Provider Callback                     | Automatically by the portal application                              | Trigger provider callback url to share client and tech user.                                                                                                       | The process step is set to "DONE" <br>after xxx                                                                                  | xxx                                        | Yes, in case of an 5xx                              | Yes, in case of an 4xx                                                                  | -                                               |
+
+<br>
+<br>
+For the app provider, following steps are needed to connect to this endpoint in the respective needed manner:
+Due to the process worker/asynchron setup of the process, the provider needs to connect to two additional endpoints to be able to fetch the status as well as the needed information for the application setup
+ - GET /api/Apps/{appId}/subscription/{subscriptionId}/provider
+ Used to watch the autosetup status via the property "processStepTypeId" as well as the technicalUserID which is needed to call the technical user credentials (next endpoint)
+ - GET /api/administration/serviceaccount/owncompany/serviceaccounts/{serviceAccountId}
+ Used to fetch the specific app tenant created technical user credentials by adding the "serviceAccountId" (aka technicalUserId) fetched via the endpoint of GET /api/Apps/{appId}/subscription/{subscriptionId}/provider
+ - PUT /subscription/{subscriptionId}/activate
+ Needed to run at the end of the customer tenant/instance configuration the activation of the subscription which will also initiate the customer information and sharing the tenantUrl
+
+<br>
+<br>
 
 ## NOTICE
 

--- a/docs/developer/Technical Documentation/Interface Contracts/Offer-Autosetup.md
+++ b/docs/developer/Technical Documentation/Interface Contracts/Offer-Autosetup.md
@@ -6,7 +6,7 @@ The offer autosetup is used to
 - the service offers two possibilities:
   - either automate the full flow; or
   - run it via any UI
- 
+
 In the page below the functional details and technical implementation possibilities are explained.
 
 ## Architecture Overview
@@ -44,11 +44,11 @@ With any further endpoint triggers; the existing record will get overwritten. Me
 <br>
 
 ##### UI Flow Details:
+
 <img width="600" alt="image" src="https://raw.githubusercontent.com/eclipse-tractusx/portal-assets/main/docs/static/register-url-popup.png">
 
 <br>
 <br>
-
 
 After the endpoint is configured, all customer service/app subscription will trigger automatically the company configured endpoint with the following data:
 
@@ -87,7 +87,7 @@ After the customer request incl the customer data for service/app setup got prov
 - ramp-up & configure the service/app
 - activate the subscription request of the customer
 
-For the *ramp-up and configuration* likely a technical user might be needed to (e.g. connect to a central provided service such as dataspace discovery, bpdm-pool, etc.). Since the offer provider did define the technical user needed profile in the app/service release process, the pre-saved configuration profile will be used now to create the technical user.
+For the _ramp-up and configuration_ likely a technical user might be needed to (e.g. connect to a central provided service such as dataspace discovery, bpdm-pool, etc.). Since the offer provider did define the technical user needed profile in the app/service release process, the pre-saved configuration profile will be used now to create the technical user.
 The app/service provider is responsible to secure the technical user credentials carefully. The technical user is a critical element since this technical user is created on the behalf of the customer (means: the technical user claims are connected to the customer identity - this is mandatorily needed since the customer is the actual acting identity of the service/app - and not the app/service provider).
 
 The app/service provider is supposed to call the endpoint which triggers the automatic creation of all app/service instance relevant informations. Therefore 2 endpoints are available
@@ -103,7 +103,6 @@ The app/service provider is supposed to call the endpoint which triggers the aut
 With the successful client/app instance creation on the portal side, the technical user for the AAS registry will get send within the response.  
 **Auth**: can get triggered by usern with the role App Manager; Service Manager and technical users with the role "Offer Management"
 
-
 Request Body
 <br>
 
@@ -115,7 +114,6 @@ Request Body
           ]
 
 <br>
-
 
 ##### API Endpoint Logic
 
@@ -177,6 +175,7 @@ Response Body
 #### Details of POST /api/Apps/start-autoSetup
 
 As an functional extencion and more app/service provider centric approach, the endpoint /api/Apps/start-autoSetup got developed which is providing:
+
 - process worker used to setup offer provider relevant objects and user notifications
 - in case of system errors or process issues, data loss is prefented by using temp data storage and automatic retriggering of processes
 
@@ -205,15 +204,15 @@ Compared to the deprecated endpoint mentioned above, the /start-autosetup is a a
 
 ## Checklist Worker
 
-| Process Step                                         | Initiated by..                                         | Description                                                                                                                                                        | Success Scenario                                                                                                                 | Error (process_step status FAILED)         | Auto Retrigger?                                     | Manual Retrigger?                                                                       | Possible Following Steps                        |
-| ---------------------------------------------------- | ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------ | --------------------------------------------------- | --------------------------------------------------------------------------------------- | ----------------------------------------------- |
-| 100<br>Trigger Provider                              | Automatically by the portal application                              | Subscription Record creation in "PENDING" <br>Portal triggers the Offer Provider URL (if provider url is stored)                                                   | If the provider endpoint is responding with 20x <br>the process step will get set to "DONE" and "SKIPPED" if no URL is available | ??                                         | Yes, in case of an 5xx                              | Yes, in case of an 400 (wrong content) 404 (wrong url)                                  | Multi Instance: #101 <br> Single Instance: #103 |
-| 101<br>Start Autosetup                               | By the provider by running .../api/Apps/start-autoSetup                              | Provider is triggering the portal autosetup endpoint with necessary offer details<br>the step will trigger the portal internal autosetup jobs (102, 103, 104, 105) | The process step is set to "DONE" <br>with successful endpoint request body (which is getting stored in a temp table)            | -                                          | -                                                   | Step stays on "TO_DO" till the endpoint got successfully triggered (content is correct) | Apps: #102 <br>Services: #104                   |
-| 102<br>OfferSubscription Client Creation             | Automatically by the portal application             | Created app client in Keycloak and DB, additionally app instance is getting created                                                                                | The process step is set to "DONE" <br>after all records are created                                                              | Status "FAILED" if job was running on fail | Yes, in case of an 5xx by keycloak                  | Yes, in case of an 4xx by keycloak                                                      | #104 <br>#105                                   |
-| 103<br>Single Instance Subscription Details Creation | By the provider by running ?????                              | Single Instance Subscription Details Creation                                                                                                                      | The process step is set to "DONE" <br>as soon as the url and instance is linked                                                  |                                            | -                                                   | -                                                                                       | #105                                            |
-| 104<br>Offr Subscription Technical User Creation     | Automatically by the portal application             | Technical User creation in keycloak and metadata storage in portal db, additionally notification creation with technical client id                                 | The process step is set to "DONE" <br>after technical user ot successfully created                                               | Status "FAILED" if job was running on fail | Yes, in case of an 5xx by keycloak                  | Yes, in case of an 4xx by keycloak                                                      | #105                                            |
-| 105<br>Activate Subscription                         | By the provider by running .../api/Apps/subscription/{offerSubscriptionId}/activate-single-instance             | Subscription record activation, notification creation and send email.                                                                                              | The process step is set to "DONE" <br>after xxx                                                                                  | xxx                                        | Yes, in case of an 5xx for the email - auto "TO_DO" | -                                                                                       | Multi Instance: #106 <br> Single Instance: -    |
-| 106<br>Trigger Provider Callback                     | Automatically by the portal application                              | Trigger provider callback url to share client and tech user.                                                                                                       | The process step is set to "DONE" <br>after xxx                                                                                  | xxx                                        | Yes, in case of an 5xx                              | Yes, in case of an 4xx                                                                  | -                                               |
+| Process Step                                         | Initiated by..                                                                                      | Description                                                                                                                                                        | Success Scenario                                                                                                                 | Error (process_step status FAILED)         | Auto Retrigger?                                     | Manual Retrigger?                                                                       | Possible Following Steps                        |
+| ---------------------------------------------------- | --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------ | --------------------------------------------------- | --------------------------------------------------------------------------------------- | ----------------------------------------------- |
+| 100<br>Trigger Provider                              | Automatically by the portal application                                                             | Subscription Record creation in "PENDING" <br>Portal triggers the Offer Provider URL (if provider url is stored)                                                   | If the provider endpoint is responding with 20x <br>the process step will get set to "DONE" and "SKIPPED" if no URL is available | ??                                         | Yes, in case of an 5xx                              | Yes, in case of an 400 (wrong content) 404 (wrong url)                                  | Multi Instance: #101 <br> Single Instance: #103 |
+| 101<br>Start Autosetup                               | By the provider by running .../api/Apps/start-autoSetup                                             | Provider is triggering the portal autosetup endpoint with necessary offer details<br>the step will trigger the portal internal autosetup jobs (102, 103, 104, 105) | The process step is set to "DONE" <br>with successful endpoint request body (which is getting stored in a temp table)            | -                                          | -                                                   | Step stays on "TO_DO" till the endpoint got successfully triggered (content is correct) | Apps: #102 <br>Services: #104                   |
+| 102<br>OfferSubscription Client Creation             | Automatically by the portal application                                                             | Created app client in Keycloak and DB, additionally app instance is getting created                                                                                | The process step is set to "DONE" <br>after all records are created                                                              | Status "FAILED" if job was running on fail | Yes, in case of an 5xx by keycloak                  | Yes, in case of an 4xx by keycloak                                                      | #104 <br>#105                                   |
+| 103<br>Single Instance Subscription Details Creation | By the provider by running ?????                                                                    | Single Instance Subscription Details Creation                                                                                                                      | The process step is set to "DONE" <br>as soon as the url and instance is linked                                                  |                                            | -                                                   | -                                                                                       | #105                                            |
+| 104<br>Offr Subscription Technical User Creation     | Automatically by the portal application                                                             | Technical User creation in keycloak and metadata storage in portal db, additionally notification creation with technical client id                                 | The process step is set to "DONE" <br>after technical user ot successfully created                                               | Status "FAILED" if job was running on fail | Yes, in case of an 5xx by keycloak                  | Yes, in case of an 4xx by keycloak                                                      | #105                                            |
+| 105<br>Activate Subscription                         | By the provider by running .../api/Apps/subscription/{offerSubscriptionId}/activate-single-instance | Subscription record activation, notification creation and send email.                                                                                              | The process step is set to "DONE" <br>after xxx                                                                                  | xxx                                        | Yes, in case of an 5xx for the email - auto "TO_DO" | -                                                                                       | Multi Instance: #106 <br> Single Instance: -    |
+| 106<br>Trigger Provider Callback                     | Automatically by the portal application                                                             | Trigger provider callback url to share client and tech user.                                                                                                       | The process step is set to "DONE" <br>after xxx                                                                                  | xxx                                        | Yes, in case of an 5xx                              | Yes, in case of an 4xx                                                                  | -                                               |
 
 <br>
 <br>

--- a/docs/developer/Technical Documentation/Interface Contracts/Offer-Autosetup.md
+++ b/docs/developer/Technical Documentation/Interface Contracts/Offer-Autosetup.md
@@ -1,6 +1,6 @@
 # Offer Autosetup
 
-The offer autosetup is used to
+The offer autosetup is used to:
 
 - enable app/service provider to configure and activate the offer subscription triggered by an customer
 - the service offers two possibilities:
@@ -20,7 +20,7 @@ In the page below the functional details and technical implementation possibilit
 
 ## Integration
 
-Every offer provider 8app as well as service) can integrate to the autosetup interface by executing following steps
+Every offer provider (app as well as service) can integrate to the autosetup interface by executing following steps
 
 1. Configure your company internal service/app ramp-up service
 2. ...
@@ -38,7 +38,7 @@ The portal provides via the UI as well as callable by technical users with the p
 **Description**: Store the service partner/app partner autosetup url. The endpoint is only available for companies with the company role app provider/service provider. Company Role change process is defined under the following link [Change Company Role](/docs/user/02.%20Technical%20Integration/05.%20Company%20Role/Change%20Company%20Role.md)  
 With the first time calling the endpoint; the url will be set as app/service provider endpoint as a new data set.  
 With any further endpoint triggers; the existing record will get overwritten. Means; the app/service provider can have only one endpoint configured.  
-**Auth**: can get triggered by usern with the role App Manager; Service Manager and technical users with the role "Offer Management"
+**Auth**: can get triggered by user with the role App Manager; Service Manager and technical users with the role "Offer Management"
 
 <br>
 <br>
@@ -81,7 +81,7 @@ After the endpoint is configured, all customer service/app subscription will tri
 
 ### #2 The autosetup flow
 
-After the customer request incl the customer data for service/app setup got provided to the offer provider, the offer provider is now supposed to
+After the customer request including the customer data for service/app setup got provided to the offer provider, the offer provider is now supposed to:
 
 - validate the request
 - ramp-up & configure the service/app
@@ -90,7 +90,7 @@ After the customer request incl the customer data for service/app setup got prov
 For the _ramp-up and configuration_ likely a technical user might be needed to (e.g. connect to a central provided service such as dataspace discovery, bpdm-pool, etc.). Since the offer provider did define the technical user needed profile in the app/service release process, the pre-saved configuration profile will be used now to create the technical user.
 The app/service provider is responsible to secure the technical user credentials carefully. The technical user is a critical element since this technical user is created on the behalf of the customer (means: the technical user claims are connected to the customer identity - this is mandatorily needed since the customer is the actual acting identity of the service/app - and not the app/service provider).
 
-The app/service provider is supposed to call the endpoint which triggers the automatic creation of all app/service instance relevant informations. Therefore 2 endpoints are available
+The app/service provider is supposed to call the endpoint which triggers the automatic creation of all app/service instance relevant information. Therefore 2 endpoints are available
 
 - POST /api/Apps/autoSetup (deprecated - still supported till 25.08.)
 - POST /api/Apps/start-autoSetup
@@ -101,7 +101,7 @@ The app/service provider is supposed to call the endpoint which triggers the aut
 **Method**: POST  
 **Description**: Post service request is used to create the customer service/app instance inside the portal db.  
 With the successful client/app instance creation on the portal side, the technical user for the AAS registry will get send within the response.  
-**Auth**: can get triggered by usern with the role App Manager; Service Manager and technical users with the role "Offer Management"
+**Auth**: can get triggered by users‚ with the role App Manager; Service Manager and technical users with the role "Offer Management"
 
 Request Body
 <br>
@@ -126,7 +126,7 @@ Request Body
 - Add app instance and client for the customer and app id in following tables
   - iam_client table
   - app_instance table
-- Next, create the client in keycloak central IdP - setting
+- Next, create the client in Keycloak central IdP - setting
 
   - Client ID: {client name defined by the service before}
   - Access Type: {public, might get auto set, please check}
@@ -174,17 +174,17 @@ Response Body
 
 #### Details of POST /api/Apps/start-autoSetup
 
-As an functional extencion and more app/service provider centric approach, the endpoint /api/Apps/start-autoSetup got developed which is providing:
+As an functional extension and more app/service provider centric approach, the endpoint /api/Apps/start-autoSetup got developed which is providing:
 
 - process worker used to setup offer provider relevant objects and user notifications
-- in case of system errors or process issues, data loss is prefented by using temp data storage and automatic retriggering of processes
+- in case of system errors or process issues, data loss is prevented by using temp data storage and automatic retriggering of processes
 
 <br>
 
 **Path**: .../api/Apps/start-autoSetup  
 **Method**: POST  
 **Description**: ...
-**Auth**: can get triggered by usern with the role App Manager; Service Manager and technical users with the role "Offer Management"
+**Auth**: can get triggered by users with the role App Manager; Service Manager and technical users with the role "Offer Management"
 
 Request Body
 <br>
@@ -198,7 +198,7 @@ Request Body
 
 <br>
 
-Compared to the deprecated endpoint mentioned above, the /start-autosetup is a asynchron endpoint working with process steps (as defined below)
+Compared to the deprecated endpoint mentioned above, the /start-autosetup is a asynchronous endpoint working with process steps (as defined below)
 
 <br>
 
@@ -208,16 +208,16 @@ Compared to the deprecated endpoint mentioned above, the /start-autosetup is a a
 | ---------------------------------------------------- | --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------ | --------------------------------------------------- | --------------------------------------------------------------------------------------- | ----------------------------------------------- |
 | 100<br>Trigger Provider                              | Automatically by the portal application                                                             | Subscription Record creation in "PENDING" <br>Portal triggers the Offer Provider URL (if provider url is stored)                                                   | If the provider endpoint is responding with 20x <br>the process step will get set to "DONE" and "SKIPPED" if no URL is available | ??                                         | Yes, in case of an 5xx                              | Yes, in case of an 400 (wrong content) 404 (wrong url)                                  | Multi Instance: #101 <br> Single Instance: #103 |
 | 101<br>Start Autosetup                               | By the provider by running .../api/Apps/start-autoSetup                                             | Provider is triggering the portal autosetup endpoint with necessary offer details<br>the step will trigger the portal internal autosetup jobs (102, 103, 104, 105) | The process step is set to "DONE" <br>with successful endpoint request body (which is getting stored in a temp table)            | -                                          | -                                                   | Step stays on "TO_DO" till the endpoint got successfully triggered (content is correct) | Apps: #102 <br>Services: #104                   |
-| 102<br>OfferSubscription Client Creation             | Automatically by the portal application                                                             | Created app client in Keycloak and DB, additionally app instance is getting created                                                                                | The process step is set to "DONE" <br>after all records are created                                                              | Status "FAILED" if job was running on fail | Yes, in case of an 5xx by keycloak                  | Yes, in case of an 4xx by keycloak                                                      | #104 <br>#105                                   |
+| 102<br>OfferSubscription Client Creation             | Automatically by the portal application                                                             | Created app client in Keycloak and DB, additionally app instance is getting created                                                                                | The process step is set to "DONE" <br>after all records are created                                                              | Status "FAILED" if job was running on fail | Yes, in case of an 5xx by Keycloak                  | Yes, in case of an 4xx by Keycloak                                                      | #104 <br>#105                                   |
 | 103<br>Single Instance Subscription Details Creation | By the provider by running ?????                                                                    | Single Instance Subscription Details Creation                                                                                                                      | The process step is set to "DONE" <br>as soon as the url and instance is linked                                                  |                                            | -                                                   | -                                                                                       | #105                                            |
-| 104<br>Offr Subscription Technical User Creation     | Automatically by the portal application                                                             | Technical User creation in keycloak and metadata storage in portal db, additionally notification creation with technical client id                                 | The process step is set to "DONE" <br>after technical user ot successfully created                                               | Status "FAILED" if job was running on fail | Yes, in case of an 5xx by keycloak                  | Yes, in case of an 4xx by keycloak                                                      | #105                                            |
+| 104<br>Offer Subscription Technical User Creation     | Automatically by the portal application                                                             | Technical User creation in Keycloak and metadata storage in portal db, additionally notification creation with technical client id                                 | The process step is set to "DONE" <br>after technical user ot successfully created                                               | Status "FAILED" if job was running on fail | Yes, in case of an 5xx by Keycloak                  | Yes, in case of an 4xx by Keycloak                                                      | #105                                            |
 | 105<br>Activate Subscription                         | By the provider by running .../api/Apps/subscription/{offerSubscriptionId}/activate-single-instance | Subscription record activation, notification creation and send email.                                                                                              | The process step is set to "DONE" <br>after xxx                                                                                  | xxx                                        | Yes, in case of an 5xx for the email - auto "TO_DO" | -                                                                                       | Multi Instance: #106 <br> Single Instance: -    |
 | 106<br>Trigger Provider Callback                     | Automatically by the portal application                                                             | Trigger provider callback url to share client and tech user.                                                                                                       | The process step is set to "DONE" <br>after xxx                                                                                  | xxx                                        | Yes, in case of an 5xx                              | Yes, in case of an 4xx                                                                  | -                                               |
 
 <br>
 <br>
 For the app provider, following steps are needed to connect to this endpoint in the respective needed manner:
-Due to the process worker/asynchron setup of the process, the provider needs to connect to two additional endpoints to be able to fetch the status as well as the needed information for the application setup
+Due to the process worker/asynchronous setup of the process, the provider needs to connect to two additional endpoints to be able to fetch the status as well as the needed information for the application setup
  - GET /api/Apps/{appId}/subscription/{subscriptionId}/provider
  Used to watch the autosetup status via the property "processStepTypeId" as well as the technicalUserID which is needed to call the technical user credentials (next endpoint)
  - GET /api/administration/serviceaccount/owncompany/serviceaccounts/{serviceAccountId}


### PR DESCRIPTION
## Description

Added customer details for the endpoint usage of /api/apps/start-autosetup

## Why

Missing details regarding needed endpoints to run the e2e process of the app subscription request configuration and activation via the endpoint /api/apps/start-autosetup

## Issue

n/a

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)