### PR TITLE
chore: remove references to catenax-ng and improve docs

### DIFF
--- a/.conf/Dockerfile
+++ b/.conf/Dockerfile
@@ -19,8 +19,8 @@
 
 #
 # usage:
-#       export NAME=tx-portal-assets
-#       export IMAGE=ghcr.io/catenax-ng/$NAME
+#       export NAME=portal-assets
+#       export IMAGE=ghcr.io/gh-example-org/$NAME
 #       docker build -t $IMAGE -f .conf/Dockerfile .
 #       docker run --rm -d -p 3000:8080 --name $NAME $IMAGE
 #       docker exec $NAME find /usr/share/nginx/html/

--- a/docs/developer/Technical Documentation/Architecture/Development Concept.md
+++ b/docs/developer/Technical Documentation/Architecture/Development Concept.md
@@ -2,17 +2,19 @@
 
 ## Build, test, deploy
 
-Details to the build, test and deploy process can get found under following link/md file:  
-https://github.com/catenax-ng/tx-portal-assets/blob/945546d91065b8870aa8f69ce94b48eac7a5ade2/docs/user/Release-Process.md
-<br>
-<br>
+Details to the build, test and deploy process can be found in the following files:
+
+- [Release Process](../Operations/Release-Process.md)
+- [Tests](../Tests/Tests.md)
+  <br>
+  <br>
 
 ## Development Guidelines
 
 The portal is using following key frameworks:
 <br>
 
-- Javascript / React
+- Typescript / React
 - .Net
 - i18n
 - Keycloak

--- a/docs/developer/Technical Documentation/Architecture/operational-concept.md
+++ b/docs/developer/Technical Documentation/Architecture/operational-concept.md
@@ -32,7 +32,7 @@ Note: will be added soon
 
 ## Logging
 
-The portal supports application and db logging. Details are stored here: https://github.com/catenax-ng/tx-portal-assets/blob/945546d91065b8870aa8f69ce94b48eac7a5ade2/docs/user/Technical%20Details/Auditing.md
+The portal supports application and db logging. Details are stored here: [Auditing](../Operations/Auditing.md).
 
 ## Monitoring
 

--- a/scripts/repo.sh
+++ b/scripts/repo.sh
@@ -28,8 +28,8 @@
 #       tx-asset-raw docs/Onboarding/Registration/FAQ.md
 #
 
-OWNER=catenax-ng
-REPO=tx-portal-assets
+OWNER=eclipse-tractusx
+REPO=portal-assets
 BASE=https://api.github.com
 BASE_RAW=https://raw.githubusercontent.com
 BRANCH=main


### PR DESCRIPTION
## Description

remove references to catenax-ng and improve docs

## Why

https://github.com/eclipse-tractusx/portal-assets/issues/210

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
