### PR TITLE
fix(documentation): fix links to GitHub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 New features, fixed bugs, known defects and other noteworthy changes to each release of the Catena-X Portal Assets.
 
+## unreleased 1.8.0-RC5
+
+### Bugfix
+
+- fixed links from documentation pages to GitHub
+
 ## 1.8.0-RC4
 
 ### Change

--- a/public/documentation/index.html
+++ b/public/documentation/index.html
@@ -1,6 +1,5 @@
 <!--
-- Copyright (c) 2021, 2023 BMW Group AG
-- Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+- Copyright (c) 2021, 2024 Contributors to the Eclipse Foundation
 -
 - See the NOTICE file(s) distributed with this work for additional
 - information regarding copyright ownership.

--- a/public/documentation/js/Main.js
+++ b/public/documentation/js/Main.js
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -282,7 +282,7 @@ class Breadcrumb extends Viewable {
         alt: 'Open in GitHub',
         href: `${Settings.SRCBASE}/${
           content.name.endsWith('.md') ? 'blob' : 'tree'
-        }/${state.releaseSelection}/${content.path}`,
+        }/${state.releaseSelection}/docs/${content.path}`,
       }
     )
   }
@@ -504,7 +504,7 @@ class Content extends Viewable {
     return this
   }
 
-  renderLink(content, hash) {
+  renderGHLink(content, hash) {
     return N(
       'a',
       N('img', null, {
@@ -516,14 +516,14 @@ class Content extends Viewable {
         alt: 'Open in GitHub',
         href: `${Settings.SRCBASE}/${
           content.name.endsWith('.md') ? 'blob' : 'tree'
-        }/${state.releaseSelection}/${content.path}#${hash}`,
+        }/${state.releaseSelection}/docs/${content.path}#${hash}`,
       }
     )
   }
 
   addHeadlineLink(item) {
     const newItem = N('div', null, { class: 'headline' })
-    const link = this.renderLink(this.content, item.id)
+    const link = this.renderGHLink(this.content, item.id)
     item.parentElement.insertBefore(newItem, item)
     item.parentElement.removeChild(item)
     newItem.appendChild(item)

--- a/public/documentation/js/Settings.js
+++ b/public/documentation/js/Settings.js
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/public/documentation/js/State.js
+++ b/public/documentation/js/State.js
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/public/documentation/js/Toolkit.js
+++ b/public/documentation/js/Toolkit.js
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.


### PR DESCRIPTION
## Description

Fix links from documentation pages to GitHub

## Why

After restructuring of the docs folders the page / chapter links to GitHub were not working anymore.

## Issue

ref. Jira CPLP-2332

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally