### PR TITLE
docs:  changes in version upgrade doc for company certificates

### DIFF
--- a/docs/developer/Technical Documentation/Version Upgrade/portal-upgrade-details.md
+++ b/docs/developer/Technical Documentation/Version Upgrade/portal-upgrade-details.md
@@ -94,52 +94,66 @@ New company_certificate_type_assigned_statuses use to map relationship between c
 Company Certificate Database Structure
 
 ```mermaid
- 
-COMPANY-CERTIFICATE{
-    int id PK
-    date valid_from
-    date valid_till
+
+%%{init: {
+  "theme": "default",
+  "themeCSS": [    
+    "[id^=entity-companycertificates] .er.entityBox { fill: lightgreen;} ",
+    "[id^=entity-companycertificatetypes] .er.entityBox { fill: lightblue;} ",
+    "[id^=entity-companycertificatetypedescriptions] .er.entityBox { fill: lightyellow;} ",
+    "[id^=entity-companycertificatestatuses] .er.entityBox { fill: pink;} ",
+    "[id^=entity-companycertificatetypeassignedstatuses] .er.entityBox { fill: silver;} ",
+    "[id^=entity-companies] .er.entityBox { fill: aqua;} ",
+    "[id^=entity-documents] .er.entityBox { fill: lightgray;} ",
+    "[id^=entity-languages] .er.entityBox { fill: orange;} "
+    ]
+}}%%
+erDiagram
+    company_certificates }|..|{ company_certificate_types : has
+    company_certificates }|..|{ company_certificate_statuses : has
+    company_certificates }|..|{ companies : has
+    company_certificates }|..|{ documents : has
+    company_certificate_type_descriptions }|..|{ company_certificate_types : has
+    company_certificate_type_descriptions }|..|{ languages : has
+    company_certificate_type_assigned_statuses ||..|{ company_certificate_types : has
+    company_certificate_type_assigned_statuses ||..|{ company_certificate_statuses : has
+
+    company_certificates{
+    uuid id PK
+    timestamp valid_from
+    timestamp valid_till
     int company_certificate_type_id FK
     int company_certificate_status_id Fk
-    int company_id Fk
-    int document_id Fk
+    uuid company_id Fk
+    uuid document_id Fk
 }
-COMPANY-CERTIFICATE-TYPE{
+company_certificate_types{
+    int id PK
+    char label
+}
+company_certificate_statuses{
     int id PK
     string label
 }
-COMPANY-CERTIFICATE-STATUS{
-    int id PK
-    string label
-}
-COMPANY-CERTIFICATE-TYPE-DESCRIPTION{
+company_certificate_type_descriptions{
     int company_certificate_type_id FK
-    string language_short_name FK
-    string description
+    char language_short_name FK
+    text description
 }
-COMPANY-CERTIFICATE-TYPE-ASSIGNED-STATUS{
+company_certificate_type_assigned_statuses{
     int company_certificate_type_id FK
     int company_certificate_status_id Fk
 }
-LANGUAGES{
-    string short_name PK
+languages{
+    char short_name PK
 }
-COMPANY{
-    int id PK
+companies{
+    uuid id PK
 }
-DOCUMENT{
-    int id PK
+documents{
+    uuid id PK
 }
-    COMPANY-CERTIFICATE }|..|{ COMPANY-CERTIFICATE-TYPE : has
-    COMPANY-CERTIFICATE }|..|{ COMPANY-CERTIFICATE-STATUS : has
-    COMPANY-CERTIFICATE }|..|{ COMPANY : has
-    COMPANY-CERTIFICATE }|..|{ DOCUMENT : has
-    COMPANY-CERTIFICATE-TYPE-DESCRIPTION }|..|{ COMPANY-CERTIFICATE-TYPE : has
-    COMPANY-CERTIFICATE-TYPE-DESCRIPTION }|..|{ LANGUAGES : has
-    COMPANY-CERTIFICATE-TYPE-ASSIGNED-STATUS ||..|{ COMPANY-CERTIFICATE-TYPE : has
-    COMPANY-CERTIFICATE-TYPE-ASSIGNED-STATUS ||..|{ COMPANY-CERTIFICATE-STATUS : has
-   
- 
+    
 ```
 
 ### v1.7.0

--- a/docs/developer/Technical Documentation/Version Upgrade/portal-upgrade-details.md
+++ b/docs/developer/Technical Documentation/Version Upgrade/portal-upgrade-details.md
@@ -85,13 +85,12 @@ erDiagram
 - NEW: portal.company_certificate_type_descriptions
 - NEW: portal.company_certificate_type_assigned_statuses
 
-
 New company_certificates table is used to store company certificates and their status  
-New company_certificate_statuses table released managing supported certificate status values (supported types can get found below) 
+New company_certificate_statuses table released managing supported certificate status values (supported types can get found below)
 New company_certificate_types_statuses table released managing supported certificate type status values (supported types can get found below)  
 New company_certificate_type table released managing supported certificate types (supported types can get found below)  
-New company_certificate_type_descriptions table released managing certificate types description in mutliple languages  
-New company_certificate_type_assigned_statuses managing the status (Active/Inactive) for company certificate types  
+New company_certificate_type_descriptions table released managing certificate types description in multiple languages  
+New company_certificate_type_assigned_statuses managing the status (Active/Inactive) for company certificate types
 
 ##### Company Certificate Database Structure
 
@@ -99,7 +98,7 @@ New company_certificate_type_assigned_statuses managing the status (Active/Inact
 
 %%{init: {
   "theme": "default",
-  "themeCSS": [    
+  "themeCSS": [
     "[id^=entity-companycertificates] .er.entityBox { fill: #DF9A9B;} ",
     "[id^=entity-companycertificatetypes] .er.entityBox { fill: #DF9A9B;} ",
     "[id^=entity-companycertificatetypedescriptions] .er.entityBox { fill: #DF9A9B;} ",
@@ -155,42 +154,39 @@ companies{
 documents{
     uuid id PK
 }
-    
+
 ```
 
 ###### Supported company_certificate_statuses:
 
-| license_type_id | license_type     |
-| --------------- | ---------------- |
-| 1               | ACTIVE           |
-| 2               | INACTIVE         |
-
+| license_type_id | license_type |
+| --------------- | ------------ |
+| 1               | ACTIVE       |
+| 2               | INACTIVE     |
 
 ###### Supported company_certificate_type_statuses:
 
-| license_type_id | license_type     |
-| --------------- | ---------------- |
-| 1               | ACTIVE           |
-| 2               | INACTIVE         |
-
+| license_type_id | license_type |
+| --------------- | ------------ |
+| 1               | ACTIVE       |
+| 2               | INACTIVE     |
 
 ###### Supported company_certificate_types:
 
-| license_type_id  | license_type     |
-| ---------------- | ---------------- |
-| 1                | AEO_CTPAT_Security_Declaration          |
-| 2                | ISO_9001         |
-| 3                | IATF_16949         |
-| 4                | ISO_14001_EMAS_or_national_certification         |
-| 5                | ISO_45001_OHSAS_18001_or_national_certification         |
-| 6                | ISO_IEC_27001         |
-| 7                | ISO_50001_or_national_certification         |
-| 8                | ISO_IEC_17025         |
-| 9                | ISO_15504_SPICE         |
-| 10               | B_BBEE_Certificate_of_South_Africa         |
-| 11               | IATF         |
-| 12               | TISAX         |
-
+| license_type_id | license_type                                    |
+| --------------- | ----------------------------------------------- |
+| 1               | AEO_CTPAT_Security_Declaration                  |
+| 2               | ISO_9001                                        |
+| 3               | IATF_16949                                      |
+| 4               | ISO_14001_EMAS_or_national_certification        |
+| 5               | ISO_45001_OHSAS_18001_or_national_certification |
+| 6               | ISO_IEC_27001                                   |
+| 7               | ISO_50001_or_national_certification             |
+| 8               | ISO_IEC_17025                                   |
+| 9               | ISO_15504_SPICE                                 |
+| 10              | B_BBEE_Certificate_of_South_Africa              |
+| 11              | IATF                                            |
+| 12              | TISAX                                           |
 
 ### v1.7.0
 

--- a/docs/developer/Technical Documentation/Version Upgrade/portal-upgrade-details.md
+++ b/docs/developer/Technical Documentation/Version Upgrade/portal-upgrade-details.md
@@ -98,14 +98,14 @@ Company Certificate Database Structure
 %%{init: {
   "theme": "default",
   "themeCSS": [    
-    "[id^=entity-companycertificates] .er.entityBox { fill: lightgreen;} ",
-    "[id^=entity-companycertificatetypes] .er.entityBox { fill: lightblue;} ",
-    "[id^=entity-companycertificatetypedescriptions] .er.entityBox { fill: lightyellow;} ",
-    "[id^=entity-companycertificatestatuses] .er.entityBox { fill: pink;} ",
-    "[id^=entity-companycertificatetypeassignedstatuses] .er.entityBox { fill: silver;} ",
-    "[id^=entity-companies] .er.entityBox { fill: aqua;} ",
-    "[id^=entity-documents] .er.entityBox { fill: lightgray;} ",
-    "[id^=entity-languages] .er.entityBox { fill: orange;} "
+    "[id^=entity-companycertificates] .er.entityBox { fill: #DF9A9B;} ",
+    "[id^=entity-companycertificatetypes] .er.entityBox { fill: #DF9A9B;} ",
+    "[id^=entity-companycertificatetypedescriptions] .er.entityBox { fill: #DF9A9B;} ",
+    "[id^=entity-companycertificatestatuses] .er.entityBox { fill: #DF9A9B;} ",
+    "[id^=entity-companycertificatetypeassignedstatuses] .er.entityBox { fill: #DF9A9B;} ",
+    "[id^=entity-companies] .er.entityBox { fill: #92A2BD;} ",
+    "[id^=entity-documents] .er.entityBox { fill: #92A2BD;} ",
+    "[id^=entity-languages] .er.entityBox { fill: #92A2BD;} "
     ]
 }}%%
 erDiagram

--- a/docs/developer/Technical Documentation/Version Upgrade/portal-upgrade-details.md
+++ b/docs/developer/Technical Documentation/Version Upgrade/portal-upgrade-details.md
@@ -1,7 +1,7 @@
 - [Summary](#summary)
   - [v1.8.0](#v180)
     - [Agreements - ENHANCED](#agreements---enhanced)
-        - [Impact on existing data:](#impact-on-existing-data)
+      - [Impact on existing data:](#impact-on-existing-data)
     - [Company Certificate Details - NEW](#company-certificate-details---new)
   - [v1.7.0](#v170)
     - [PostgreSQL - Upgrade](#postgresql---upgrade)

--- a/docs/developer/Technical Documentation/Version Upgrade/portal-upgrade-details.md
+++ b/docs/developer/Technical Documentation/Version Upgrade/portal-upgrade-details.md
@@ -80,18 +80,20 @@ erDiagram
 
 - NEW: portal.company_certificates
 - NEW: portal.company_certificate_types
+- NEW: portal.company_certificate_type_statuses
 - NEW: portal.company_certificate_statuses
 - NEW: portal.company_certificate_type_descriptions
 - NEW: portal.company_certificate_type_assigned_statuses
 
-New company_certificates table released to be able to create translatable company certificates.
-New company_certificate_types, company_certificate_type_statuses tables to store the certificate type and certificate status which are mapped with company-certificates.
-New company_certificate_types is use tp map specific certificate type for specific condition.
-New company_certificate_statuses use to keep status of company certificate.
-New company_certificate_type_descriptions keeps the each company_certificate_types with specific language code with description.
-New company_certificate_type_assigned_statuses use to map relationship between company_certificate_types and company_certificate_statuses.
 
-Company Certificate Database Structure
+New company_certificates table is used to store company certificates and their status  
+New company_certificate_statuses table released managing supported certificate status values (supported types can get found below) 
+New company_certificate_types_statuses table released managing supported certificate type status values (supported types can get found below)  
+New company_certificate_type table released managing supported certificate types (supported types can get found below)  
+New company_certificate_type_descriptions table released managing certificate types description in mutliple languages  
+New company_certificate_type_assigned_statuses managing the status (Active/Inactive) for company certificate types  
+
+##### Company Certificate Database Structure
 
 ```mermaid
 
@@ -155,6 +157,40 @@ documents{
 }
     
 ```
+
+###### Supported company_certificate_statuses:
+
+| license_type_id | license_type     |
+| --------------- | ---------------- |
+| 1               | ACTIVE           |
+| 2               | INACTIVE         |
+
+
+###### Supported company_certificate_type_statuses:
+
+| license_type_id | license_type     |
+| --------------- | ---------------- |
+| 1               | ACTIVE           |
+| 2               | INACTIVE         |
+
+
+###### Supported company_certificate_types:
+
+| license_type_id  | license_type     |
+| ---------------- | ---------------- |
+| 1                | AEO_CTPAT_Security_Declaration          |
+| 2                | ISO_9001         |
+| 3                | IATF_16949         |
+| 4                | ISO_14001_EMAS_or_national_certification         |
+| 5                | ISO_45001_OHSAS_18001_or_national_certification         |
+| 6                | ISO_IEC_27001         |
+| 7                | ISO_50001_or_national_certification         |
+| 8                | ISO_IEC_17025         |
+| 9                | ISO_15504_SPICE         |
+| 10               | B_BBEE_Certificate_of_South_Africa         |
+| 11               | IATF         |
+| 12               | TISAX         |
+
 
 ### v1.7.0
 

--- a/docs/developer/Technical Documentation/Version Upgrade/portal-upgrade-details.md
+++ b/docs/developer/Technical Documentation/Version Upgrade/portal-upgrade-details.md
@@ -1,6 +1,8 @@
 - [Summary](#summary)
   - [v1.8.0](#v180)
     - [Agreements - ENHANCED](#agreements---enhanced)
+        - [Impact on existing data:](#impact-on-existing-data)
+    - [Company Certificate Details - NEW](#company-certificate-details---new)
   - [v1.7.0](#v170)
     - [PostgreSQL - Upgrade](#postgresql---upgrade)
     - [Company Service Account - FIX](#company-service-account---fix)
@@ -72,6 +74,72 @@ erDiagram
         int id PK
         char label
     }
+```
+
+#### Company Certificate Details - NEW
+
+- NEW: portal.company_certificates
+- NEW: portal.company_certificate_types
+- NEW: portal.company_certificate_statuses
+- NEW: portal.company_certificate_type_descriptions
+- NEW: portal.company_certificate_type_assigned_statuses
+
+New company_certificates table released to be able to create translatable company certificates.
+New company_certificate_types, company_certificate_type_statuses tables to store the certificate type and certificate status which are mapped with company-certificates.
+New company_certificate_types is use tp map specific certificate type for specific condition.
+New company_certificate_statuses use to keep status of company certificate.
+New company_certificate_type_descriptions keeps the each company_certificate_types with specific language code with description.
+New company_certificate_type_assigned_statuses use to map relationship between company_certificate_types and company_certificate_statuses.
+
+Company Certificate Database Structure
+
+```mermaid
+ 
+COMPANY-CERTIFICATE{
+    int id PK
+    date valid_from
+    date valid_till
+    int company_certificate_type_id FK
+    int company_certificate_status_id Fk
+    int company_id Fk
+    int document_id Fk
+}
+COMPANY-CERTIFICATE-TYPE{
+    int id PK
+    string label
+}
+COMPANY-CERTIFICATE-STATUS{
+    int id PK
+    string label
+}
+COMPANY-CERTIFICATE-TYPE-DESCRIPTION{
+    int company_certificate_type_id FK
+    string language_short_name FK
+    string description
+}
+COMPANY-CERTIFICATE-TYPE-ASSIGNED-STATUS{
+    int company_certificate_type_id FK
+    int company_certificate_status_id Fk
+}
+LANGUAGES{
+    string short_name PK
+}
+COMPANY{
+    int id PK
+}
+DOCUMENT{
+    int id PK
+}
+    COMPANY-CERTIFICATE }|..|{ COMPANY-CERTIFICATE-TYPE : has
+    COMPANY-CERTIFICATE }|..|{ COMPANY-CERTIFICATE-STATUS : has
+    COMPANY-CERTIFICATE }|..|{ COMPANY : has
+    COMPANY-CERTIFICATE }|..|{ DOCUMENT : has
+    COMPANY-CERTIFICATE-TYPE-DESCRIPTION }|..|{ COMPANY-CERTIFICATE-TYPE : has
+    COMPANY-CERTIFICATE-TYPE-DESCRIPTION }|..|{ LANGUAGES : has
+    COMPANY-CERTIFICATE-TYPE-ASSIGNED-STATUS ||..|{ COMPANY-CERTIFICATE-TYPE : has
+    COMPANY-CERTIFICATE-TYPE-ASSIGNED-STATUS ||..|{ COMPANY-CERTIFICATE-STATUS : has
+   
+ 
 ```
 
 ### v1.7.0


### PR DESCRIPTION
## Description

document for release 1.8.0 the change made in version upgrade doc for developer

 company certificates - https://github.com/eclipse-tractusx/sig-release/issues/326

## Why

new feature database tables for company certificate reference added.

Please include an explanation of why this change is necessary as well as relevant motivation and context. List any dependencies that are required for this change.

## Issue

#264
#255

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have added copyright and license headers, footers (for .md files) or files (for images)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
