### PR TITLE
docs(upgrade): add documentation of new encryption-configuration for osp

### DIFF
--- a/docs/developer/Technical Documentation/Version Upgrade/portal-upgrade-details.md
+++ b/docs/developer/Technical Documentation/Version Upgrade/portal-upgrade-details.md
@@ -30,6 +30,68 @@ Each section includes the respective change details, impact on existing data and
 
 > **_INFO:_** inside the detailed descriptions below, the definition 'migration script' refers to the term 'migrations' as it is defined by the ef-core framework: https://learn.microsoft.com/en-us/ef/core/managing-schemas/migrations
 
+#### OnboardingServiceProvider - ENHANCED
+
+ - ENHANCED: table onboarding_service_provider_details "encryption_mode" added
+ - ENHANCED: table onboarding_service_provider_details "initialization_vector" added
+
+ - ENHANCED: configuration for onboarding-service-provider:
+ 
+```
+    "OnboardingServiceProvider": {
+      "EncrptionConfigIndex": 1,
+      "EncryptionConfigs": [
+        {
+          "Index": 0,
+          "EncryptionKey": "",
+          "CipherMode": "",
+          "PaddingMode": ""
+        },
+        {
+          "Index": 1,
+          "EncryptionKey": "",
+          "CipherMode": "",
+          "PaddingMode": ""
+        }
+      ]
+    }
+```
+Previous OnboardingServiceProvider settings contained 'EncryptionKey'. Format was utf8-string being read as byte[].
+New format of EncryptionKey is 64 characters hex
+
+Example:
+  - old format:
+```
+    "OnboardingServiceProvider": {
+      "EcryptionKey": ")U\;>/h=ELj+.v5AD9(P2HQ3JnuYt.R:"
+    }
+```
+  - including the details that before the change were defined in the sourcecode the same configuration as 'index 0' in new format:
+```
+    "OnboardingServiceProvider": {
+      "EncrptionConfigIndex": 1,
+      "EncryptionConfigs": [
+        {
+          "Index": 0,
+          "EncryptionKey": "29555c3b3e2f683d454c6a2b2e76354144392850324851334a6e7559742e523a",
+          "CipherMode": "ECB",
+          "PaddingMode": "PKCS7"
+        },
+        {
+          "Index": 1,
+          "EncryptionKey": "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+          "CipherMode": "CBC",
+          "PaddingMode": "PKCS7"
+        }
+      ]
+    }
+```
+
+to ensure the new encryption is able to decrypt preexisting client_secrets the old encryption-key must be converted to the new format. This may be done on the command-line:
+```
+echo -n ")U\;>/h=ELj+.v5AD9(P2HQ3JnuYt.R:" | xxd -p
+```
+
 ### v1.8.0
 
 #### Agreements - ENHANCED

--- a/docs/developer/Technical Documentation/Version Upgrade/portal-upgrade-details.md
+++ b/docs/developer/Technical Documentation/Version Upgrade/portal-upgrade-details.md
@@ -32,14 +32,14 @@ Each section includes the respective change details, impact on existing data and
 
 #### OnboardingServiceProvider - ENHANCED
 
- - ENHANCED: table onboarding_service_provider_details "encryption_mode" added
- - ENHANCED: table onboarding_service_provider_details "initialization_vector" added
+- ENHANCED: table onboarding_service_provider_details "encryption_mode" added
+- ENHANCED: table onboarding_service_provider_details "initialization_vector" added
 
- - ENHANCED: configuration for onboarding-service-provider:
- 
+- ENHANCED: configuration for onboarding-service-provider:
+
 ```
     "OnboardingServiceProvider": {
-      "EncrptionConfigIndex": 1,
+      "EncryptionConfigIndex": 1,
       "EncryptionConfigs": [
         {
           "Index": 0,
@@ -56,20 +56,25 @@ Each section includes the respective change details, impact on existing data and
       ]
     }
 ```
+
 Previous OnboardingServiceProvider settings contained 'EncryptionKey'. Format was utf8-string being read as byte[].
 New format of EncryptionKey is 64 characters hex
 
 Example:
-  - old format:
+
+- old format:
+
 ```
     "OnboardingServiceProvider": {
-      "EcryptionKey": ")U\;>/h=ELj+.v5AD9(P2HQ3JnuYt.R:"
+      "EncryptionKey": ")U\;>/h=ELj+.v5AD9(P2HQ3JnuYt.R:"
     }
 ```
-  - including the details that before the change were defined in the sourcecode the same configuration as 'index 0' in new format:
+
+- including the details that before the change were defined in the source code the same configuration as 'index 0' in new format:
+
 ```
     "OnboardingServiceProvider": {
-      "EncrptionConfigIndex": 1,
+      "EncryptionConfigIndex": 1,
       "EncryptionConfigs": [
         {
           "Index": 0,
@@ -88,6 +93,7 @@ Example:
 ```
 
 to ensure the new encryption is able to decrypt preexisting client_secrets the old encryption-key must be converted to the new format. This may be done on the command-line:
+
 ```
 echo -n ")U\;>/h=ELj+.v5AD9(P2HQ3JnuYt.R:" | xxd -p
 ```


### PR DESCRIPTION
## Description

technical documentation has been added that describe the details of new OnboardingServiceProvider EncryptionConfig.

## Why

To enable a stronger encryption for OnboardingServiceProvider ClientSecrets https://github.com/eclipse-tractusx/portal-backend/pull/531 includes changes that allow the configuration of encryption-algorithm properties cipher-mode, padding-mode and encryption-key. Multiple configuration can be specified. To ensure existing data can be decrypted after the upgrade the first configuration must match the one that was being used before the change.

## Issue

https://github.com/eclipse-tractusx/portal-backend/issues/437

## Checklist

Please delete options that are not relevant.

- [X] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [X] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [X] I have performed a self-review of my own code
- [X] I have successfully tested my changes locally
