### PR TITLE
fix: adjust initial wallet script

### DIFF
--- a/docs/developer/Technical Documentation/Operator Wallet Setup/Initial Setup.md
+++ b/docs/developer/Technical Documentation/Operator Wallet Setup/Initial Setup.md
@@ -44,7 +44,7 @@ After you ensured that no company_application exists for the operator company, t
         ('e85cf473-0321-4428-818a-3e595086ac94', 21, 1, now(), null, '9782562f-5ba1-467f-b4da-a8d50d727145', null);
 
     INSERT INTO portal.company_applications(id, date_created, date_last_changed, application_status_id, company_id, last_editor_id, checklist_process_id, company_application_type_id, onboarding_service_provider_id)
-    VALUES ('31322991-f6fd-4a40-a529-566c9b04d6a4', now(), null, 8, 'your company id', null, '9782562f-5ba1-467f-b4da-a8d50d727145', 1, null);
+    VALUES ('31322991-f6fd-4a40-a529-566c9b04d6a4', now(), null, 7, 'your company id', null, '9782562f-5ba1-467f-b4da-a8d50d727145', 1, null);
 
     INSERT INTO portal.application_checklist(application_id, application_checklist_entry_type_id, date_created, date_last_changed, application_checklist_entry_status_id, comment)
         VALUES ('31322991-f6fd-4a40-a529-566c9b04d6a4', 1, now(), null, 3, null),


### PR DESCRIPTION
## Description

adjust script to add the application to create the initial operator wallet

## Why

the script creates the application in state confirmed, but it must be in state `SUBMITTED` to be picked up by the application checklist process

## Issue

Refs: #362

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have added copyright and license headers, footers (for .md files) or files (for images)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
