### PR TITLE
docs: add diagrams for clearinghouse self descriptions disabling

### DIFF
--- a/docs/developer/01. Registration/04. Registration Approval/Toogle.md
+++ b/docs/developer/01. Registration/04. Registration Approval/Toogle.md
@@ -1,13 +1,9 @@
 ```mermaid
 flowchart TD
-    TD
     A[Registration]
-    B{Clearinghouse Connect Disabled}
-    A --> B
+    A --> D 
     C[Legal Person SD Creation skipped]
     D[ToDo]
-    B -->|True| C
-    B -->|False| D
     E[Done]
     F[Failed]
     H{Clearinghouse Connect Disabled}

--- a/docs/developer/01. Registration/04. Registration Approval/Toogle.md
+++ b/docs/developer/01. Registration/04. Registration Approval/Toogle.md
@@ -1,0 +1,94 @@
+```mermaid
+flowchart TD
+    TD
+    A[Registration]
+    B{Clearinghouse Connect Disabled}
+    A --> B
+    C[Legal Person SD Creation skipped]
+    D[ToDo]
+    B -->|True| C
+    B -->|False| D
+    E[Done]
+    F[Failed]
+    H{Clearinghouse Connect Disabled}
+    I{Call SD Factory}
+    D --> H
+    H -->|True|C
+    H -->|False|I
+    I -->|Success|E
+    I -->|Failure|F
+    F -->|"Retrigger Call to SD Factory Processstep (legal person)"|D
+    J[Await Self Description Response]
+    E --> J
+    K[Application Activation]
+    J -->|set SD-DocumentId on Company| K
+    C --> K
+    AA[Application Checklist Level]
+    AE[Data Validation]
+    AF[BPN Creation]
+    AG[Identity Wallet Creation]
+    AH[Clearing House]
+    AI["Self Description (Status TODO)"]
+    AA --> AE
+    AE --> AF
+    AF --> AG
+    AG --> AH
+    AH --> AI
+    AI --> AB
+    AB{Clearinghouse Connect Disabled}
+    AB -->|False| AJ
+    AJ{Call SD Factory}
+    AK["Self Description (Status FAILED)"]
+    AD[APPROVED]
+    AB -->|True|AC
+    AJ -->|Success|AD
+    AJ -->|Failure|AK
+    AK -->|"Retrigger Call to SD Factory Processstep (legal person)"|AI
+    AC["Self Description (Status SKIPPED)"]
+    AL[Application Activated]
+    AC --> AL
+    AD --> AL
+    BA[Connector Registration]
+    BB{Clearinghouse Connect Disabled}
+    BA --> BB
+    BB -->|True|BE
+    BB -->|False|BD
+    BD{Company SD available}
+    BE[Connector Registration]
+    BF[Error 409]
+    BD -->|True|BE
+    BD -->|False|BF
+    BG[Status Active]
+    BE --> BG
+    BH[Connector SD Registration Active]
+    BG --> BH
+    CA[Company SD Document Recreate]
+    CB[Select Company without SD]
+    CA --> CB
+    CC[Call SD Factory]
+    CB -->|exists| CC
+    CD[Store SD with Company]
+    CE[DONE]
+    CB -->|does not exist|CE
+    CF{Company SD Factory available}
+    CC --> CF
+    CF -->|Success|CD
+    CD --> CB
+    CG[FAILED]
+    CF -->|Failure|CG
+
+    DA[Connctor SD Document Recreate]
+    DB[Select Connector without SD]
+    DA --> DB
+    DC[Call SD Factory]
+    DB -->|exists| DC
+    DD[Store SD with Connector]
+    DE[DONE]
+    DB -->|does not exist|DE
+    DF{Connector SD Factory available}
+    DC --> DF
+    DF -->|Success|DD
+    DD --> DB
+    DG[FAILED]
+    DF -->|Failure|DG
+```

--- a/docs/developer/10. Disable Clearinghouse SD/Use-Case-Diagrams.md
+++ b/docs/developer/10. Disable Clearinghouse SD/Use-Case-Diagrams.md
@@ -1,7 +1,11 @@
+# Disable Clearinghouse connectivity for Self-Description (SD) functionalities
+
+## Registration
+
 ```mermaid
 flowchart TD
     A[Registration]
-    A --> D 
+    A --> D
     C[Legal Person SD Creation skipped]
     D[ToDo]
     E[Done]
@@ -19,16 +23,26 @@ flowchart TD
     K[Application Activation]
     J -->|set SD-DocumentId on Company| K
     C --> K
+```
+
+## Application Checklist Level
+
+```mermaid
+flowchart TD
     AA[Application Checklist Level]
-    AE[Data Validation]
-    AF[BPN Creation]
-    AG[Identity Wallet Creation]
-    AH[Clearing House]
-    AI["Self Description (Status TODO)"]
+    AE[REGISTRATION_VERIFICATION = DONE]
+    AF[BUSINESS_PARTNER_NUMBER = DONE]
+    AG[IDENTITY_WALLET = DONE]
+    AGA[BPNL_CREDENTIAL = DONE]
+    AGB[MEMBERSHIP_CREDENTIAL = DONE]
+    AH[CLEARING_HOUSE = DONE]
+    AI[SELF_DESCRIPTION_LP = TODO]
     AA --> AE
     AE --> AF
     AF --> AG
-    AG --> AH
+    AG --> AGA
+    AGA --> AGB
+    AGB --> AH
     AH --> AI
     AI --> AB
     AB{Clearinghouse Connect Disabled}
@@ -41,50 +55,76 @@ flowchart TD
     AJ -->|Failure|AK
     AK -->|"Retrigger Call to SD Factory Processstep (legal person)"|AI
     AC["Self Description (Status SKIPPED)"]
-    AL[Application Activated]
+    AL[APPLICATION_ACTIVATION = TODO]
+    AL[APPLICATION_ACTIVATION = DONE]
     AC --> AL
     AD --> AL
+```
+
+## Connector Registration
+
+```mermaid
+flowchart TD
     BA[Connector Registration]
     BB{Clearinghouse Connect Disabled}
     BA --> BB
     BB -->|True|BE
     BB -->|False|BD
-    BD{Company SD available}
+    BD{"Legal Person SD available (self_description_document_id)" }
     BE[Connector Registration]
     BF[Error 409]
-    BD -->|True|BE
+    BD -->|True|BI
+    BI[Call SD Factory]
+    BI -->|Pending|BH
     BD -->|False|BF
-    BG[Status Active]
-    BE --> BG
-    BH[Connector SD Registration Active]
-    BG --> BH
+    BE -->|Status Active| BH
+    BH[Set Connector Status]
+```
+
+## Company SD Document Recreate
+
+```mermaid
+  flowchart TD
     CA[Company SD Document Recreate]
-    CB[Select Company without SD]
+    CB["Select Company without SD (SD Step Status = SKIPPED or DONE)"]
     CA --> CB
     CC[Call SD Factory]
     CB -->|exists| CC
     CD[Store SD with Company]
     CE[DONE]
     CB -->|does not exist|CE
-    CF{Company SD Factory available}
+    CF{Company SD available}
     CC --> CF
     CF -->|Success|CD
     CD --> CB
     CG[FAILED]
     CF -->|Failure|CG
+```
 
-    DA[Connctor SD Document Recreate]
-    DB[Select Connector without SD]
+## Connector SD Document Recreate
+
+```mermaid
+  flowchart TD
+    DA[Connector SD Document Recreate]
+    DB["Select Connector(Status=Active & Without Connector SD Document & With Company SD Document)"]
     DA --> DB
     DC[Call SD Factory]
     DB -->|exists| DC
     DD[Store SD with Connector]
     DE[DONE]
     DB -->|does not exist|DE
-    DF{Connector SD Factory available}
+    DF{Connector SD available}
     DC --> DF
     DF -->|Success|DD
     DD --> DB
     DG[FAILED]
     DF -->|Failure|DG
 ```
+
+## NOTICE
+
+This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
+
+- SPDX-License-Identifier: Apache-2.0
+- SPDX-FileCopyrightText: 2024 Contributors to the Eclipse Foundation
+- Source URL: https://github.com/eclipse-tractusx/portal-assets

--- a/docs/developer/10. Disable Clearinghouse SD/index.md
+++ b/docs/developer/10. Disable Clearinghouse SD/index.md
@@ -1,0 +1,13 @@
+# Summary
+
+TBD
+
+- [Use Case Diagrams](../10.%20Disable%20Clearinghouse%20SD/Use-Case-Diagrams.md)
+
+## NOTICE
+
+This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
+
+- SPDX-License-Identifier: Apache-2.0
+- SPDX-FileCopyrightText: 2024 Contributors to the Eclipse Foundation
+- Source URL: https://github.com/eclipse-tractusx/portal-assets


### PR DESCRIPTION
## Description

add diagrams for clearinghouse self descriptions disabling

## Issue

https://github.com/eclipse-tractusx/sig-release/issues/796

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have added copyright and license headers, footers (for .md files) or files (for images)
- [x] I have performed a self-review of my own changes
