### PR TITLE
docs: adjust delete technical user documentation

### DIFF
--- a/docs/developer/03. User Management/03. Technical User/04. Delete Technical User.md
+++ b/docs/developer/03. User Management/03. Technical User/04. Delete Technical User.md
@@ -28,7 +28,7 @@ flowchart TD
      offer subscription`"}
     D --> |true| G(409 Error)
     F --> |false| H{Is external user}
-    H --> |true| I{"`Create process
+    H --> |true| I{"`Create process still
      in progress`"}
     I --> |true| J("`Skip all creation process steps
      set state to DELETE`")

--- a/docs/developer/03. User Management/03. Technical User/04. Delete Technical User.md
+++ b/docs/developer/03. User Management/03. Technical User/04. Delete Technical User.md
@@ -5,29 +5,42 @@ To delete an user, just open up the user details and click the "delete" button.
 
 <img width="558" alt="image" src="https://raw.githubusercontent.com/eclipse-tractusx/portal-assets/main/docs/static/delete-technical-user.png">
 
-<br>
-<br>
-<br>
-<br>
-
 #### Currently not supported:
 
 update technical user secret
-
-<br>
-<br>
 
 ### Delete Service Account
 
 Delete an existing service account  
 Only service accounts of the own company can get deleted.
 Permission: "delete_tech_user_management"
-<br>
-<br>
+
 As part of the deletion API, the following tasks get executed:
 
-- Delete service account inside the central identity provider
-- Technical user record is set to "INACTIVE"
+```mermaid
+flowchart TD
+    A(API delete call) -->|Pass the service account id| B["`Receive service account
+     for company`"]
+    B --> C{Service account exists and user has access}
+    C --> |true| D{"`Linked to active/pending connector`"}
+    C --> |false| E(409 Error)
+    D --> |false| F{"`Linked to active
+     offer subscription`"}
+    D --> |true| G(409 Error)
+    F --> |false| H{Is external user}
+    H --> |true| I{"`Create process
+     in progress`"}
+    I --> |true| J("`Skip all creation process steps
+     set state to DELETE`")
+    I --> |false| K("`Create delete process
+    set state to PENDING_DELETION`")
+    H --> |false| L{has clientCLientId}
+    L --> |true| M(Delete client from keycloak)
+    L --> |false| N(set state to DELETE)
+    M --> N
+```
+
+Endpoint can be called via:
 
 ```diff
 ! DELETE: api/administration/owncompany/serviceaccounts/{serviceAccountId}
@@ -36,24 +49,9 @@ As part of the deletion API, the following tasks get executed:
 Validation:
 
 - only owned or managed service account can get deleted
-- the deletion is not possible if the user is linked to an active subscription
-
-<br>
-
-<br>
-
-Request body
-
-    	n/a
-    	managed via endpoint path
-
-<br>
-<br>
+- the deletion is not possible if the user is linked to an active subscription or an connector in state active or pending
 
 > **_NOTE:_** Technical user owner as well as provider (managed tech user owner) can run the delete endpoint - however deletion is not possible if subscription/connector are still active.
-
-<br>
-<br>
 
 ## NOTICE
 

--- a/docs/developer/03. User Management/03. Technical User/04. Delete Technical User.md
+++ b/docs/developer/03. User Management/03. Technical User/04. Delete Technical User.md
@@ -21,23 +21,23 @@ As part of the deletion API, the following tasks get executed:
 flowchart TD
     A(API delete call) -->|Pass the service account id| B["`Receive service account
      for company`"]
-    B --> C{Service account exists and user has access}
+    B --> C{Service account exists is active and user has access}
     C --> |true| D{"`Linked to active/pending connector`"}
-    C --> |false| E(409 Error)
+    C --> |false| E("Error 404 - serviceAccount {serviceAccountId} not found for company {companyId}")
     D --> |false| F{"`Linked to active
      offer subscription`"}
-    D --> |true| G(409 Error)
+    D --> |true| G("`Error 409 - Technical User is linked to an active connector. Change the link or deactivate the connector to delete the technical user.`")
     F --> |false| H{Is external user}
-    H --> |true| I{"`Create process still
+    F --> |true| I("`Error 409 - Technical User is linked to an active subscription. Deactivate the subscription to delete the technical user.`")
+    H --> |true| J{"`Create process still
      in progress`"}
-    I --> |true| J("`Skip all creation process steps
-     set state to DELETE`")
-    I --> |false| K("`Create delete process
+    J --> |true| K("`Error 409 - Technical user can't be deleted because the creation progress is still running`")
+    J --> |false| L("`Create delete process
     set state to PENDING_DELETION`")
-    H --> |false| L{has clientCLientId}
-    L --> |true| M(Delete client from keycloak)
-    L --> |false| N(set state to DELETE)
-    M --> N
+    H --> |false| M{has clientCLientId}
+    M --> |true| N(Delete client from keycloak)
+    M --> |false| O(set state to DELETE)
+    N --> O
 ```
 
 Endpoint can be called via:
@@ -48,10 +48,10 @@ Endpoint can be called via:
 
 Validation:
 
-- only owned or managed service account can get deleted
-- the deletion is not possible if the user is linked to an active subscription or an connector in state active or pending
+- only owned or managed service account that are active can get deleted
+- the deletion is not possible if the user is linked to an `active` offer subscription or an connector in state `active` or `pending`
 
-> **_NOTE:_** Technical user owner as well as provider (managed tech user owner) can run the delete endpoint - however deletion is not possible if subscription/connector are still active.
+> **_NOTE:_** Technical user owner as well as provider (managed tech user owner) can run the delete endpoint.
 
 ## NOTICE
 

--- a/docs/developer/03. User Management/03. Technical User/04. Delete Technical User.md
+++ b/docs/developer/03. User Management/03. Technical User/04. Delete Technical User.md
@@ -34,7 +34,7 @@ flowchart TD
     J --> |true| K("`Error 409 - Technical user can't be deleted because the creation progress is still running`")
     J --> |false| L("`Create delete process
     set state to PENDING_DELETION`")
-    H --> |false| M{has clientCLientId}
+    H --> |false| M{has clientClientId}
     M --> |true| N(Delete client from keycloak)
     M --> |false| O(set state to DELETE)
     N --> O


### PR DESCRIPTION
## Description

Adjust the technical user delete documentation

## Why

The process was adjusted for external users

## Issue

Refs: https://github.com/eclipse-tractusx/portal-backend/issues/950

## Corresponding Backend PR

https://github.com/eclipse-tractusx/portal-backend/pull/956

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have added copyright and license headers, footers (for .md files) or files (for images)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
