### PR TITLE
docs: adjust delete technical user documentation

### DIFF
--- a/docs/developer/03. User Management/03. Technical User/04. Delete Technical User.md
+++ b/docs/developer/03. User Management/03. Technical User/04. Delete Technical User.md
@@ -9,21 +9,23 @@ To delete an user, just open up the user details and click the "delete" button.
 
 update technical user secret
 
-### Delete Service Account
+### Delete Technical User
 
-Delete an existing service account  
-Only service accounts of the own company can get deleted.
+Delete an existing technical user
+Only technical users of the own company can get deleted.
 Permission: "delete_tech_user_management"
 
 As part of the deletion API, the following tasks get executed:
 
 ```mermaid
 flowchart TD
-    A(API delete call) -->|Pass the service account id| B["`Receive service account
+    A(API delete call) -->|Pass the technical user id| B["`Receive technical user
      for company`"]
-    B --> C{Service account exists is active and user has access}
-    C --> |true| D{"`Linked to active/pending connector`"}
-    C --> |false| E("Error 404 - serviceAccount {serviceAccountId} not found for company {companyId}")
+    B --> C{Check technical user}
+    C --> |existing & active| D{"`Linked to active/pending connector`"}
+    C --> |not existing| E("Error 404 - serviceAccount {serviceAccountId} does not exist")
+    C --> |technical user not active| P("Error 409 - technical user {serviceAccountId} is not status active")
+    C --> |technical user owned by other company| Q("Error 403 - Only provider or owner of the technical user are allowed to delete it")
     D --> |false| F{"`Linked to active
      offer subscription`"}
     D --> |true| G("`Error 409 - Technical User is linked to an active connector. Change the link or deactivate the connector to delete the technical user.`")
@@ -48,7 +50,7 @@ Endpoint can be called via:
 
 Validation:
 
-- only owned or managed service account that are active can get deleted
+- only owned or managed technical user that are active can get deleted
 - the deletion is not possible if the user is linked to an `active` offer subscription or an connector in state `active` or `pending`
 
 > **_NOTE:_** Technical user owner as well as provider (managed tech user owner) can run the delete endpoint.


### PR DESCRIPTION
## Description

Adjusting error codes for the technical user delete

## Why

To give an overview of the possible error messages of the backend

## Issue

Refs: https://github.com/eclipse-tractusx/portal-backend/issues/986

## Backend PR

https://github.com/eclipse-tractusx/portal-backend/pull/995

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have added copyright and license headers, footers (for .md files) or files (for images)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x ] I have commented my code, particularly in hard-to-understand areas
