### PR TITLE
fix(Use Case Participation): incorrect Manage UseCase Credentials url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ New features, fixed bugs, known defects and other noteworthy changes to each rel
 ### BugFixes
 
 - **Use Case Participation**
-  - fixed Manage UseCase Credentials url
+  - fixed Manage UseCase Credentials url [#416](https://github.com/eclipse-tractusx/portal-assets/pull/416)
 
 ## 2.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ New features, fixed bugs, known defects and other noteworthy changes to each rel
 
 - updated technical user overview with technical user details and also updated relevant images.
 
+### BugFixes
+
+- **Use Case Participation**
+  - fixed Manage UseCase Credentials url
+
 ## 2.2.0
 
 ### Change

--- a/public/assets/content/de/dataspace.json
+++ b/public/assets/content/de/dataspace.json
@@ -134,7 +134,7 @@
           {
             "background": "#C498EF63",
             "title": "UseCase-Teilnahmeinformationen verwalten",
-            "navigate": "/usecase-participation"
+            "navigate": "/usecaseParticipation"
           },
           {
             "background": "#C498EF63",

--- a/public/assets/content/en/dataspace.json
+++ b/public/assets/content/en/dataspace.json
@@ -134,7 +134,7 @@
           {
             "background": "#C498EF63",
             "title": "Manage UseCase Credentials",
-            "navigate": "/usecase-participation"
+            "navigate": "/usecaseParticipation"
           },
           {
             "background": "#C498EF63",


### PR DESCRIPTION
## Description

fixed incorrect Manage UseCase Credentials url.

## Why

Need fix the Manage UseCase Credentials url because the current url not working.

## Issue

https://github.com/eclipse-tractusx/portal-frontend/issues/1152

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have added copyright and license headers, footers (for .md files) or files (for images)
- [x] I have performed a self-review of my own code

