### PR TITLE
fix(dataspace): fix "Manage Role Credentials" link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ New features, fixed bugs, known defects and other noteworthy changes to each rel
 
 ## Unreleased
 
+## 2.3.0-RC1
+
 ### Change
 
 #### Documentation
@@ -12,8 +14,10 @@ New features, fixed bugs, known defects and other noteworthy changes to each rel
 
 ### BugFixes
 
-- **Use Case Participation**
-  - fixed Manage UseCase Credentials url [#416](https://github.com/eclipse-tractusx/portal-assets/pull/416)
+#### Assets
+
+- **Dataspace Page**
+  - fixed "Manage UseCase Credentials" and "Manage Role Credentials" links [#416](https://github.com/eclipse-tractusx/portal-assets/pull/425), [#416](https://github.com/eclipse-tractusx/portal-assets/pull/425)
 
 ## 2.2.0
 

--- a/public/assets/content/de/dataspace.json
+++ b/public/assets/content/de/dataspace.json
@@ -139,7 +139,7 @@
           {
             "background": "#C498EF63",
             "title": "Rollen-Teilnahmeinformationen verwalten",
-            "navigate": "/certificate-credential"
+            "navigate": "/certificateCredential"
           }
         ],
         "linksRow2": [

--- a/public/assets/content/en/dataspace.json
+++ b/public/assets/content/en/dataspace.json
@@ -139,7 +139,7 @@
           {
             "background": "#C498EF63",
             "title": "Manage Role Credentials",
-            "navigate": "/certificate-credential"
+            "navigate": "/certificateCredential"
           }
         ],
         "linksRow2": [


### PR DESCRIPTION
## Description

fix "Manage Role Credentials" link on Dataspace page

## Why

https://github.com/eclipse-tractusx/portal-frontend/issues/1152

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
