### PR TITLE
docs(user): fix of typos and grammar in 00. and 01.

### DIFF
--- a/docs/user/00. Personas/Onboarding Service Provider (OSP).md
+++ b/docs/user/00. Personas/Onboarding Service Provider (OSP).md
@@ -19,7 +19,7 @@ The purpose of OSPs is to enable a faster growth of the the network on the one h
 
 ### Find & Access OSPs
 
-The first step is to find an OSP. You're existing partners, that happen to be OSPs for Catena-X might inform you about their status as OSPs and offer you the opportunitity to become a participant in the Catena-X network. Alternatively you can find the list provided by the association, that lists all available OSPs. The individual onboarding process depends on the OSPs individual implementation. That might ie. be a registration form or a semi automatic process handled by your OSP. Ideally you get in contact with them and discuss the available options in order to figure out the availale/best ways to proceed.
+The first step is to find an OSP. You're existing partners, that happen to be OSPs for Catena-X might inform you about their status as OSPs and offer you the opportunity to become a participant in the Catena-X network. Alternatively you can find the list provided by the association, that lists all available OSPs. The individual onboarding process depends on the OSPs individual implementation. That might ie. be a registration form or a semi automatic process handled by your OSP. Ideally you get in contact with them and discuss the available options in order to figure out the available/best ways to proceed.
 As soon as you registered with you OSP, please follow this [guide](/docs/user/01.%20Onboarding/04.%20OSP/01.%20Onboarding%20with%20an%20OSP.md).
 
 ## NOTICE

--- a/docs/user/01. Onboarding/01. Registration Invite/02. FAQ.md
+++ b/docs/user/01. Onboarding/01. Registration Invite/02. FAQ.md
@@ -6,7 +6,7 @@
 ## How can I invite a potential new Catena-X member?
 
 In the first implementation level, Catena-X members can get invited by the operator only.
-a potential new membership can get initiated by existing members by writing a email to the operator and request the invite. Please make sure that you mention the
+A potential new membership can get initiated by existing members by writing a email to the operator and request the invite. Please make sure that you mention the
 
 - Company Name
 - Contact Person
@@ -19,7 +19,7 @@ a potential new membership can get initiated by existing members by writing a em
 ## Can I identify already invited members?
 
 Normal users can not identify companies which are currently in the registration process, but as soon as the registration is finished, the membership will be visible via the partner network.
-If you go to the partner network and search for a company, check out the membership icon. If the CX icon is displayed (example see screenshot below) the company is member of Catena-X.
+If you go to the partner network and search for a company, check out the membership icon. If the CX icon is displayed (example see screenshot below) the company is a member of Catena-X.
 <br>
 <br>
 <img width="800" alt="image" src="https://raw.githubusercontent.com/eclipse-tractusx/portal-assets/main/docs/static/company-search-results.png">

--- a/docs/user/01. Onboarding/02. Registration/03. Add Additional User(s).md
+++ b/docs/user/01. Onboarding/02. Registration/03. Add Additional User(s).md
@@ -3,14 +3,14 @@
 #optional step#
 
 The 2nd step inside the registration form is optional. Means, the user can invite additional company members if support in the registration is needed.
-Normally this should only be relevant if an user is not authorized to finish the registration in the name of the company. E.g. missing rights to agree to terms and conditions or similar scenarios.  
+Normally this should only be relevant if a user is not authorized to finish the registration in the name of the company. E.g. missing rights to agree to terms and conditions or similar scenarios.  
 <br>
 <img width="366" alt="image" src="https://raw.githubusercontent.com/eclipse-tractusx/portal-assets/main/docs/static/registration-invite-user.png">
 
 <br<
 
-With the invite of an user, a personal message can get entered to ensure that the invited user knows the purpose of the invite.
-Below an example of the email send to the invited user is shared:
+With the invite of a user, a personal message can get entered to ensure that the invited user knows the purpose of the invite.
+Below an example of the email sent to the invited user can be found:
 
 <img width="450" alt="image" src="https://raw.githubusercontent.com/eclipse-tractusx/portal-assets/main/docs/static/invite-registration.png">
 

--- a/docs/user/01. Onboarding/02. Registration/04. Company Role & Consent.md
+++ b/docs/user/01. Onboarding/02. Registration/04. Company Role & Consent.md
@@ -1,7 +1,7 @@
 #### Company Role & Terms and Conditions
 
 Under step 3 "Company Roles & Agreements" the applicator is requested to select the company role with which the application company want to participate inside the network. Beside the "Active Participant", "App Provider" and "Service Provider" are available. Depending on the role, the network agreements/terms and conditions which the application company needs to agree on are getting displayed. Also, the role i relevant to manage the respective access rights/permissions which the application company will receive inside the Catena-X network.  
-The role can get easily enhanced in future by enhancing or reducing the role inside the company configuration (available inside the CX Portal).  
+The role can get easily enhanced in the future by enhancing or reducing the role inside the company configuration (available inside the CX Portal).  
 <br>
 
 <img width="441" alt="image" src="https://raw.githubusercontent.com/eclipse-tractusx/portal-assets/main/docs/static/registration-company-role.png">

--- a/docs/user/01. Onboarding/02. Registration/05. Document Upload.md
+++ b/docs/user/01. Onboarding/02. Registration/05. Document Upload.md
@@ -2,7 +2,7 @@
 
 In Step 4, the users are asked to upload the company identification.
 <br>
-All documents uploaded under the same application register form are shown. If a second user has already uploaded a doc, the user will be able to see as well as delete this document as well; as long as the users belong to the same company application.  
+All documents uploaded under the same application register form are shown. If a second user has already uploaded a doc, the user will be able to see as well as delete this document; as long as the users belong to the same company application.  
 <br>
 
 <img width="536" alt="image" src="https://raw.githubusercontent.com/eclipse-tractusx/portal-assets/main/docs/static/upload-documents-screen.png">

--- a/docs/user/01. Onboarding/02. Registration/06. Verify Registration Data.md
+++ b/docs/user/01. Onboarding/02. Registration/06. Verify Registration Data.md
@@ -1,10 +1,10 @@
 ## Submit company data
 
 The last step of the company application is the verification of the data.
-The user can revalidate if al data are correctly added. In case anything is wrong or missing, the "back" button will support to update any entered data.  
+The user can revalidate if all data are correctly added. In case anything is wrong or missing, the "back" button will support to update any entered data.  
 <br>
 
-With the submit of the application, the application form is getting closed and the company application data are submitted for review to the platform operator. The application verification will run through a number of identification validations as well as technical setup to enable the company to participate inside the dataspace.
+With the submission of the application, the application form is closed and the company application data are submitted for review to the platform operator. The application verification will run through a number of identification validations as well as the technical setup to enable the company to participate inside the dataspace.
 <br>
 
 <img width="421" alt="image" src="https://raw.githubusercontent.com/eclipse-tractusx/portal-assets/main/docs/static/registration-verify.png">

--- a/docs/user/01. Onboarding/02. Registration/07. FAQ.md
+++ b/docs/user/01. Onboarding/02. Registration/07. FAQ.md
@@ -10,8 +10,8 @@ The company registration data are used to register the company in the network an
 
 ## What will happen after the registration?
 
-As soon as the company registration got submitted, the Catena-X operator will validate the data for correctness and start the automatic registration process. This includes the legal validation, the Gaia-X compliance check as well as the creation of the company account.
-The process can take up to 48 hours. As soon as the process is successfully processed, the user will get informed and the access to the network will be given. All details are getting shared via email.
+As soon as the company registration is submitted, the Catena-X operator will validate the data for correctness and initiate the automatic registration process. This includes the legal validation, the Gaia-X compliance check as well as the creation of the company account.
+The process can take up to 48 hours. As soon as the process is successfully processed, the user will be informed and the access to the network will be given. All details are shared via email.
 <br>
 <br>
 
@@ -21,16 +21,16 @@ You can pause with the company registration whenever you want. To proceed with t
 <br>
 <br>
 
-## What can I do, if I dont have all necessary information available, which are needed to register my company?
+## What can I do, if I don't have all necessary information available, which are needed to register my company?
 
 Whenever you want, you can pause the registration.
 If pausing the registration is not enough, you can also use the optional step #2 and invite another person to support the registration. E.g. a person with the necessary permission level to provide the necessary approvals or to upload the necessary documents.
 <br>
 <br>
 
-## Why do I always receive a message / warning screen when logging in to the registration form of my company.
+## Why do I always receive a message / warning screen when logging in to the registration form of my company?
 
-In case the registration is already submitted for validation; the company wont be able to change / adjust any company registration relevant data anymore. The registration form is officially closed and the user need to wait for the registration form validation to finish.
+In case the registration is already submitted for validation; the company wont be able to change / adjust any company registration relevant data anymore. The registration form is officially closed and the user needs to wait for the registration form validation to finish.
 <br>
 <br>
 

--- a/docs/user/01. Onboarding/03. Registration Approval/02. View Company Application(s).md
+++ b/docs/user/01. Onboarding/03. Registration Approval/02. View Company Application(s).md
@@ -15,7 +15,7 @@ Inside the offered board; the user can
 ### Display Application Details
 
 <br>
-With using the application details button, application details such as
+Using the application details button, application details such as
 <br>
 <br>
 

--- a/docs/user/01. Onboarding/03. Registration Approval/03. Registration Approval Process.md
+++ b/docs/user/01. Onboarding/03. Registration Approval/03. Registration Approval Process.md
@@ -21,15 +21,15 @@ flowchart LR
     start to participate and share`")
 ```
 
-As highlevel displayed above; the registration approval flow consist out of 7 steps. Which can partially run in parallel or must run in the predefined sequence.
-The seven registration approval flow steps are implemented in a kind of an checklist worker which automatically triggers the relevant services as per the current state of the company application. To ensure that the operator knows the status of the company application, each step can be in the status
+As high-level displayed above; the registration approval flow consist out of 7 steps. Which can partially run in parallel or must run in the predefined sequence.
+The seven registration approval flow steps are implemented in a kind of checklist worker which automatically triggers the relevant services as per the current state of the company application. To ensure that the operator knows the status of the company application, each step can be in the status
 
 - Open
 - In Progress
 - Done
 - Failed
 
-In case of an failed scenario; the error code (if available) is getting recorded for the registration application workflow step and can get viewed by the operator.
+In case of a failed scenario; the error code (if available) is getting recorded for the registration application workflow step and can get viewed by the operator.
 
 For the Self Description creation there was a special status `Skipped` introduced. This step is only set if the clearinghouseConnectDisabled is true.
 
@@ -38,7 +38,7 @@ For the Self Description creation there was a special status `Skipped` introduce
 <img width="1406" alt="image" src="https://raw.githubusercontent.com/eclipse-tractusx/portal-assets/main/docs/static/application-requests-popup.png">
 
 By clicking on the process step overview on the right side, the overlay wth process step details gets displayed.
-Depending on the status, the user can execute a number of action / next steps. In general 3 action states are possible and defined below
+Depending on the status, the user can execute a number of actions / next steps. In general 3 action states are possible and defined below
 
 <img width="1540" alt="image" src="https://raw.githubusercontent.com/eclipse-tractusx/portal-assets/main/docs/static/status-frontend-options.png">
 
@@ -82,34 +82,34 @@ The decline scenario is not reversible. The registration company will get inform
 ##### Details "Create Business Partner Number (if necessary)"
 
 <br>
-The status "Business_Partner_Number" is getting updated based on the application registration content.
+The status "Business_Partner_Number" is being updated based on the application registration content.
 
 <br>
 <br>
 
 ###### Scenario 1 - Registration with BPN
 
-If the registration application is getting submitted by the registration party for approval with an BPN, the checklist item "Business Partner Number" is getting set to "DONE".
+If the registration application is being submitted by the registration party for approval with a BPN, the checklist item "Business Partner Number" is set to "DONE".
 In this case; nothing is needed anymore regarding the business partner number checklist item.
 <br>
 <br>
 
 ###### Scenario 2 - Registration without BPN
 
-If the registration application is getting submitted by the registration party for approval <strong>without an BPN</strong>, the checklist item "Business Partner Number" is kept in status "TO_DO"
+If the registration application is being submitted by the registration party for approval <strong>without an BPN</strong>, the checklist item "Business Partner Number" is kept in status "TO_DO"
 
 In this case; the checklist item worker will fetch the application when running and submit the company data of the registration company to the business partner golden record gateway to validate the record and to generate a business partner number.
 <br>
 
 ```diff
-! POST /api/administration/registration/application/{applicationId}/trigger-bpn
+! POST /api/administration/registration/application/{applicationId}/trigger-BPN
 ```
 
-the checklist item "Business Partner Number" is getting set to "IN_PROGRESS", till a BPN is received (currently not yet implemented)
+the checklist item "Business Partner Number" is getting set to "IN_PROGRESS", until a BPN is received (currently not yet implemented)
 <br>
 <br>
 
-    Please note - in the current implementation the bpn gate response does mainly handle success scenarios. In the Scenario of an fail (due to incorrect/not matching company data) the failure response is not yet available and will be delivered by the bpdm product team asap.
+    Please note - in the current implementation the BPN gate response does mainly handle success scenarios. In the Scenario of an fail (due to incorrect/not matching company data) the failure response is not yet available and will be delivered by the bpdm product team asap.
 
 <br>
 <br>
@@ -117,11 +117,11 @@ the checklist item "Business Partner Number" is getting set to "IN_PROGRESS", ti
 ###### Scenario 3 - manually add BPN as operator (interim supported workflow)
 
 For the interim process of the need to add the BPN of the new CX participant manually, the operator can use the endpoint to add the business partner number to the application.
-This endpoint is an interim endpoint only and supposed to get disabled; as soon as the BPN Gateway is providing a stable feedback on provided company data.
+This endpoint is an interim endpoint only and supposed to get disabled; as soon as the BPN Gateway is providing a stable feedback on the provided company data.
 <br>
 
 ```diff
-! POST /api/administration/registration/application/{applicationId}/{bpn}/bpn
+! POST /api/administration/registration/application/{applicationId}/{BPN}/BPN
 ```
 
 <br>
@@ -133,7 +133,7 @@ This endpoint is an interim endpoint only and supposed to get disabled; as soon 
 After the checklist item "Registration_Verification" status is set to "DONE", as well as the status of the "Business_Partner_Number" automatically the IF to the identity wallet is getting triggered to create the company identity wallet.
 Details to the company identity wallet can get found inside the identity wallet product description.
 
-With triggering the registration; the company name as well as the bpn are getting submitted and stored inside the company wallet.
+With triggering the registration, the company name as well as the BPN are getting submitted and stored inside the company wallet.
 
 Depending on the API response, the system will behave in the following way:
 
@@ -160,16 +160,16 @@ The BPNL Credential is requested via the SSI Credential Issuer, after successful
 After the SSI Credential Issuer created the credential a callback is made:
 
 ```diff
-! POST: api/administration/registration/issuer/bpncredential
+! POST: api/administration/registration/issuer/BPNcredential
 ```
 
 {
-"bpn": "string",
+"BPN": "string",
 "status": "string",
 "message": "string"
 }
 
-The status can only get changed/updated; if the status of the application checklist attribute "request bpnl credential" is "IN_PROGRESS".
+The status can only get changed/updated; if the status of the application checklist attribute "request BPNl credential" is "IN_PROGRESS".
 
 ##### Details "Request Membership Credential"
 
@@ -191,7 +191,7 @@ After the SSI Credential Issuer created the credential a callback is made:
 ```
 
 {
-"bpn": "string",
+"BPN": "string",
 "status": "string",
 "message": "string"
 }
@@ -213,7 +213,7 @@ The "Clearinghouse Check" is getting automatically triggered when following prer
 <img width="450" alt="image" src="https://raw.githubusercontent.com/eclipse-tractusx/portal-assets/main/docs/static/selfdescription-backend-flow.png">
 <br>
 
-The interface is an asyncron interface - due to this; the interface is explained below in two steps
+The interface is an asynchronous interface - due to this, the interface is explained below in two steps
 
 <br>
 <br>
@@ -231,7 +231,7 @@ Submitted body to clearinghouse endpoint (content is created on backend side onl
                 "name": "string",
                 "city": "string",
                 "street": "string",
-                "bpn": "string",
+                "BPN": "string",
                 "region": "string",
                 "zipCode": "string",
                 "country": "string",
@@ -253,10 +253,10 @@ Submitted body to clearinghouse endpoint (content is created on backend side onl
 
 ###### Step 2 - Clearinghouse response
 
-In the asynchronous call of the clearinghouse check; the portal provides an POST endpoint, which can get triggered by the clearinghouse to update the checklist status.  
+In the asynchronous call of the clearinghouse check, the portal provides a POST endpoint, which can get triggered by the clearinghouse to update the checklist status.  
 <br>
 
-the clearinghouse need to be able to store an fail/success message. the message is supposed to get stored inside the checklist comment of the record attribute "clearing_house"
+the clearinghouse need to be able to store an fail/success message. the message is supposed to be stored inside the checklist comment of the record attribute "clearing_house"
 <br>
 
 ```diff
@@ -264,12 +264,12 @@ the clearinghouse need to be able to store an fail/success message. the message 
 ```
 
         {
-          "bpn": "string",
+          "BPN": "string",
           "status": "string",
           "message": "string"
         }
 
-The bpn inside the request body is used to fetch the correct application Id. (application in status "submitted")
+The BPN inside the request body is used to fetch the correct application Id. (application in status "submitted")
 The status can only get changed/updated; if the status of the application checklist attribute "clearing_house" is "IN_PROGRESS".
 
 ##### Details "Self-Description Creation LegalPerson"
@@ -287,7 +287,7 @@ The "Self_Description_Legal_Person" is getting automatically triggered when foll
 
 Before executing the application checklist item a check for `clearinghouseConnectDisabled` is active, if `clearinghouseConnectDisabled` is true the status of the application checklist item is set to `SKIPPED` and the logic won't be executed.
 
-With the endpoint; the SD Factory is getting triggered and a self description of the legal person is getting submitted back. The portal backend is storing the self-description inside the portal db linked to the company.
+With the endpoint, the SD Factory is triggered and a self description of the legal person is submitted back. The portal backend is storing the self-description inside the portal DB linked to the company.
 
 With triggering the endpoint, the status of the checklist item "Self_Description_LP" is set to "IN_PROGRESS"
 
@@ -334,7 +334,7 @@ flowchart TD
 ```
 
 <br>
-The complete company account activation (as result of the successful application checklist finalization) is automatically executed when following pre-requisites are fullfilled:
+The complete company account activation (as result of the successful application checklist finalization) is automatically executed when following pre-requisites are fulfilled:
 <br>
 
 - application checklist status "Business_Partner_Number" = "DONE"
@@ -355,18 +355,18 @@ With the execution of the application activation, the system will:
 - set invitation of all users to "CLOSED"
 - set invitation time stamp
 - update user roles (portal db and Keycloak)
-- add bpn to user(s)
+- add BPN to user(s)
 - send welcome email
 
 ### Add/Update BPN for the registration company
 
 <br>
-The bpn can get manually added (as an workaround) if the registration company request doesn't have a business partner number added and the registration request is in status "submitted".
+The BPN can be manually added (as a workaround) if the registration company request doesn't have a business partner number added and the registration request is in status "submitted".
 <br>
 <img width="1213" alt="image" src="https://raw.githubusercontent.com/eclipse-tractusx/portal-assets/main/docs/static/application-requests-possible-interactions.png">
 <br>
-BPNs can only get added by CX Admin's.
-As mentioned above, the implementation is a workaround only and will get replaced by the actual bpn connection as soon as the reference implementation is available.
+BPNs can only be added by CX Admin's.
+As mentioned above, the implementation is a workaround only and will get replaced by the actual BPN connection as soon as the reference implementation is available.
 <br>
 <br>
 

--- a/docs/user/01. Onboarding/03. Registration Approval/04. Decline Application.md
+++ b/docs/user/01. Onboarding/03. Registration Approval/04. Decline Application.md
@@ -1,6 +1,6 @@
 ## Decline Company Application
 
-While the company application is processing the application validations; the administrator can decline the application whenever wanted.
+While the company application is processing the application validations, the administrator can decline the application whenever wanted.
 
 To decline the application the "Cancel Application" Button is enabled for all applications which did not reach the "CONFIRMED" / "DECLINED" status so far
 (application hasn't been officially approved (CONFIRMED) or rejected (DECLINED) yet).
@@ -17,7 +17,7 @@ Here's what to expect after canceling:
 <br>
 
 > **Warning**
-> In the current state of implementation the checklist worker and manual process intervention such as the cancellation have no validation/check implemented where the services can validate if the other service might already run. Means; in the unlikely case that the cancellation is triggered while the activation is running in parallel; the activation might overrule the cancellation.
+> In the current state of implementation the checklist worker and manual process intervention such as the cancellation have no validation/check implemented where the services can validate if the other service might already run. Meaning, in the unlikely case that the cancellation is triggered while the activation is running in parallel; the activation might overrule the cancellation.
 > The scenario is very unlikely and will get handled in an upcoming release.
 
 <br>
@@ -35,13 +35,13 @@ including your spam folder, for any notifications regarding the cancellation.
 
 #### 3. How will I know if my application has been cancelled?
 
-You will receive an email notification if your application is canceled. Be sure to check your spam folder if you do not see the email in your inbox. Additionally, you can log in to your account to check the status of
+You will receive an email notification if your application was canceled. Be sure to check your spam folder if you do not see the email in your inbox. Additionally, you can log in to your account to check the status of
 your application.
 
 #### 4. What should I do if my application was cancelled by mistake?
 
 If your application was canceled, you will need to submit a new application. Currently, there is no way to reverse a cancellation.
-A new registration invite needs to get triggered by the operator and the registration form needs to get newly filled out.
+A new registration invite needs to get triggered by the operator and the registration form needs to get filled out again.
 
 <br>
 

--- a/docs/user/01. Onboarding/03. Registration Approval/05. FAQ.md
+++ b/docs/user/01. Onboarding/03. Registration Approval/05. FAQ.md
@@ -2,8 +2,8 @@
 
 ### What happens if I decline an application?
 
-In case of an application "decline", the user(s) registered under the registration account are getting informed about the rejection.
-Additionally an information of the reject reason (if available) is getting shared.
+In case of an application "decline", the user(s) registered under the registration account will be informed about the rejection.
+Additionally an information of the rejection reason (if available) is getting shared.
 
 <br>
 <br>
@@ -11,7 +11,7 @@ Additionally an information of the reject reason (if available) is getting share
 ### Can I as a registration company view my registration status?
 
 The registration status itself can not get checked. The only information available is the information displayed inside the registration form that the registration is under validation.
-As soon as the validation is finished you will get informed about the next possible steps via email.
+As soon as the validation is finished you will be informed about the next possible steps via email.
 
 <br>
 <br>

--- a/docs/user/01. Onboarding/04. OSP/01. Onboarding with an OSP.md
+++ b/docs/user/01. Onboarding/04. OSP/01. Onboarding with an OSP.md
@@ -14,13 +14,13 @@ When you first log in, you will be prompted with an overlay that asks you to con
 
 ### Status Overlay
 
-You will then see an overlay that tells you about the status of your registration. The individual steps, that need to be checked and done prior to your final registration will be listed here. You can close it at any time and can reopen it with the bar at the top. The required steps are the same as they are for a regular operator triggered registration. That also includes the generation of the BPNL. As soon as all steps have been finished successfully, you will receive an status information mail.
+You will then see an overlay that tells you about the status of your registration. The individual steps, that need to be checked and done prior to your final registration will be listed here. You can close it at any time and can reopen it with the bar at the top. The required steps are the same as they are for a regular operator triggered registration. That also includes the generation of the BPNL. As soon as all steps have been finished successfully, you will receive a status information mail.
 <br>
 **Please Note:** you do not need to perform anything here, these are automatic steps, that generally do not require your active participation at that point.
 
 ### Decline Registration
 
-In case you received the earlier mentioned welcome mail and you do not want to part of the dataspace, you can scroll down to the bottom of the page and click the link for declining the registration.
+In case you received the earlier mentioned welcome mail and you do not want to be part of the dataspace, you can scroll down to the bottom of the page and click the link for declining the registration.
 
 ## NOTICE
 


### PR DESCRIPTION
## Description

Several typos and grammar issues, were fixed in docs/user/00.&01.

## Why

For better readability

## Issue

n/a

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
