### PR TITLE
docs(offersubscription): fixed the callback url post body

### DIFF
--- a/docs/admin/Interface Contracts/Offer-Autosetup.md
+++ b/docs/admin/Interface Contracts/Offer-Autosetup.md
@@ -214,15 +214,20 @@ Endpoint an app-provider is supposed to call to confirm the final activation of 
 
 ```
 {
-  "technicalUserInfo":
+  "technicalUserInfo": [
     {
-      "technicalUserId": "string" (id of technical user, guid)
-      "technicalUserSecret": "string" (secret of technical user)
-      "technicalClientId": "string" (clientId of technical user)
-    },
+      "technicalUserId": "string"    (guid, id of the technical user),
+      "technicalUserPermissions": [
+        "string"                     (permissions that were assigned to the given technicalUserId)
+      ],
+      "technicalUserSecret": "string", (secret of the technical user)
+      "technicalClientId": "string" (clientId of the technical user)
+    }
+  ],
   "clientInfo":
     {
-      "clientId": "string" (clientId of created app-instance)
+      "clientId": "clientId of the app-instances keycloak-client",
+      "clientUrl": "url of the app-instance"
     }
 }
 ```

--- a/docs/admin/Interface Contracts/Offer-Autosetup.md
+++ b/docs/admin/Interface Contracts/Offer-Autosetup.md
@@ -223,8 +223,7 @@ Endpoint an app-provider is supposed to call to confirm the final activation of 
   ],
   "clientInfo":
     {
-      "clientId": "clientId of the app-instances keycloak-client",
-      "clientUrl": "url of the app-instance"
+      "clientId": "clientId of the app-instances keycloak-client"
     }
 }
 ```

--- a/docs/admin/Interface Contracts/Offer-Autosetup.md
+++ b/docs/admin/Interface Contracts/Offer-Autosetup.md
@@ -217,9 +217,6 @@ Endpoint an app-provider is supposed to call to confirm the final activation of 
   "technicalUserInfo": [
     {
       "technicalUserId": "string"    (guid, id of the technical user),
-      "technicalUserPermissions": [
-        "string"                     (permissions that were assigned to the given technicalUserId)
-      ],
       "technicalUserSecret": "string", (secret of the technical user)
       "technicalClientId": "string" (clientId of the technical user)
     }


### PR DESCRIPTION
## Description

Updated the request body sent in the callback URL 

## Why

Now the app can have multiple technical users, so this fix is to enable the code to send multiple technical users to the callback URL.

## Issue

[#1307](https://github.com/eclipse-tractusx/portal-backend/issues/1307)

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally

NOTE: Please merge only after [PR-1318](https://github.com/eclipse-tractusx/portal-backend/pull/1318) has been merged
