### PR TITLE
ci(yarn): fail install if package changes were not applied

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Install Dependencies
-        run: yarn
+        run: yarn --frozen-lockfile
 
       - name: Create metadata
         run: yarn build:release

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -32,8 +32,23 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
+      # Install Dependencies
+      # Using --frozen-lockfile first to fail fast if yarn.lock is out of sync
+      # Run a second time since yarn v1 frozen-lockfile does not notice removed dependencies
       - name: Install Dependencies
-        run: yarn
+        run: |
+          yarn --frozen-lockfile
+          yarn
+
+      - name: Check for uncommitted files in working directory
+        run: |
+          git_status=$(git status --porcelain)
+          if [ -n "$git_status" ]; then
+            echo "Please commit changed files before running checks."
+            exit 1
+          else
+            echo "No modified files found."
+          fi
 
       - name: Prettier checks
         run: yarn pretty:check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
           echo versions equal - building release ${{ env.REF_NAME }}
 
       - name: Install Dependencies
-        run: yarn
+        run: yarn --frozen-lockfile
 
       - name: Create release version metadata
         run: yarn build:release ${{ env.REF_NAME }}


### PR DESCRIPTION
## Description

Add --frozen-lockfile to workflows and add additional check in pr-checks to prevent uncommitted changes.

## Why

Prevent de-sync of package.json and yarn.lock. Otherwise unintended package version changes could be included in builds.

## Issue

#502

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commits-branches-and-pull-requests-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
