### PR TITLE
build(2.6.0): update changelog and upgrade details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 New features, fixed bugs, known defects and other noteworthy changes to each release of the Catena-X Portal Assets.
 
+## 2.6.0-RC1
+
+### Change
+
+#### Technical Support
+
+- ci improvement to fail install if package changes were not applied [#501](https://github.com/eclipse-tractusx/portal-assets/pull/501/files)
+
 ## 2.5.0
 
 ### Change

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 New features, fixed bugs, known defects and other noteworthy changes to each release of the Catena-X Portal Assets.
 
-## 2.6.0-RC1
+## 2.6.0
 
 ### Change
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cx-portal-assets",
-  "version": "v2.5.0",
+  "version": "v2.6.0-RC1",
   "description": "Shared frontend content and static assets for the Catena-X Portal",
   "main": "index.js",
   "repository": "git@github.com:eclipse-tractusx/portal-assets.git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cx-portal-assets",
-  "version": "v2.6.0-RC1",
+  "version": "v2.6.0",
   "description": "Shared frontend content and static assets for the Catena-X Portal",
   "main": "index.js",
   "repository": "git@github.com:eclipse-tractusx/portal-assets.git",


### PR DESCRIPTION
## Description

- update changelog for v2.6.0

## Why

To have all changes visible in the changelog.

## Issue

eclipse-tractusx/portal#567

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have added copyright and license headers, footers (for .md files) or files (for images)
- [x] I have performed a self-review of my own code
